### PR TITLE
Fix closing about dialog on btn click

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -40,6 +40,7 @@ var FlatsealApplication = GObject.registerClass({
 
     _displayAbout() {
         const dialog = new FlatsealAboutDialog({transient_for: this._window, modal: true});
+        dialog.connect('response', dialog => dialog.close());
         dialog.present();
     }
 


### PR DESCRIPTION
I had found that the close button on the about dialog didn't worked for me. So I just looked at GTK3's JS bindings for the first time to find this bug.