### PR TITLE
Group permissions

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatseal\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-01 01:00-0300\n"
+"POT-Creation-Date: 2020-03-03 12:59-0300\n"
 "PO-Revision-Date: 2020-03-01 13:28+0100\n"
 "Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
 "Language-Team: none\n"
@@ -56,85 +56,133 @@ msgstr "Aplikace"
 msgid "No applications found."
 msgstr "Nenalezeny žádné aplikace."
 
-#: src/model.js:33
-msgid "Access network"
-msgstr "Přístup k síti"
+#: src/model.js:24
+msgid "List of subsystems shared with the host system"
+msgstr ""
 
-#: src/model.js:38
-msgid "Access inter-process communications"
+#: src/model.js:25
+msgid "List of well-known sockets available in the sandbox"
+msgstr ""
+
+#: src/model.js:26
+msgid "List of devices available in the sandbox"
+msgstr ""
+
+#: src/model.js:27
+#, fuzzy
+msgid "List of features available to the application"
+msgstr "V této aplikaci nebyly provedeny žádné změny"
+
+#: src/model.js:28
+msgid "List of filesystem subsets available to the application"
+msgstr ""
+
+#: src/model.js:41
+msgid "Network"
+msgstr ""
+
+#: src/model.js:46
+#, fuzzy
+msgid "Inter-process communications"
 msgstr "Přístup k meziprocesové komunikaci"
 
-#: src/model.js:43
-msgid "Access X11 windowing system"
+#: src/model.js:51
+#, fuzzy
+msgid "X11 windowing system"
 msgstr "Přístup k okennímu systému X11"
 
-#: src/model.js:48
-msgid "Access Wayland windowing system"
+#: src/model.js:56
+#, fuzzy
+msgid "Wayland windowing system"
 msgstr "Přístup k okennímu systému Wayland"
 
-#: src/model.js:53
-msgid "Access X11 windowing system (as fallback)"
-msgstr "Přístup k okennímu systému X11 (jako rezerva)"
+#: src/model.js:61
+#, fuzzy
+msgid "Fallback to X11 windowing system"
+msgstr "Přístup k okennímu systému X11"
 
-#: src/model.js:58
-msgid "Access PulseAudio sound server"
+#: src/model.js:66
+#, fuzzy
+msgid "PulseAudio sound server"
 msgstr "Přístup ke zvukovému serveru PulseAudio"
 
-#: src/model.js:63
-msgid "Access D-Bus session bus (unrestricted)"
+#: src/model.js:71
+#, fuzzy
+msgid "D-Bus session bus"
 msgstr "Přístup ke sběrnici sezení D-Bus (neomezený)"
 
-#: src/model.js:68
-msgid "Access D-Bus system bus (unrestricted)"
-msgstr "Přístup k systémové sběrnici D-Bus (neomezený)"
+#: src/model.js:76
+msgid "D-Bus system bus"
+msgstr ""
 
-#: src/model.js:73
-msgid "Access Secure Shell agent"
+#: src/model.js:81
+#, fuzzy
+msgid "Secure Shell agent"
 msgstr "Přístup k agentu Zabezpečeného Shellu"
 
-#: src/model.js:78
-msgid "Access smart cards"
+#: src/model.js:86
+#, fuzzy
+msgid "Smart cards"
 msgstr "Přístup k chytrým kartám"
 
-#: src/model.js:83
-msgid "Access printing system"
+#: src/model.js:91
+#, fuzzy
+msgid "Printing system"
 msgstr "Přístup k tiskovému systému"
 
-#: src/model.js:88
-msgid "Access GPU acceleration"
+#: src/model.js:96
+#, fuzzy
+msgid "GPU acceleration"
 msgstr "Přístup k akceleraci GPU"
 
-#: src/model.js:93
-msgid "Access virtualization"
+#: src/model.js:101
+#, fuzzy
+msgid "Virtualization"
 msgstr "Přístup k virtualizaci"
 
-#: src/model.js:98
-msgid "Access shared memory (e.g. JACK sound server)"
+#: src/model.js:106
+#, fuzzy
+msgid "Shared memory (e.g. JACK sound server)"
 msgstr "Přístup ke sdílené paměti (např. Zvukový server JACK)"
 
-#: src/model.js:103
-msgid "Access all devices (e.g. webcam)"
+#: src/model.js:111
+#, fuzzy
+msgid "All devices (e.g. webcam)"
 msgstr "Přístup ke všem zařízením (např. webkameře)"
 
-#: src/model.js:108
-msgid "Access other syscalls (e.g. ptrace)"
+#: src/model.js:116
+#, fuzzy
+msgid "Development syscalls (e.g. ptrace)"
 msgstr "Přístup k jiným systémovým voláním (např. ptrace)"
 
-#: src/model.js:113
-msgid "Access programs from other architectures"
+#: src/model.js:121
+#, fuzzy
+msgid "Programs from other architectures"
 msgstr "Přístup k programům z jiných architektur"
 
-#: src/model.js:118
-msgid "Access Bluetooth"
+#: src/model.js:126
+#, fuzzy
+msgid "Bluetooth"
 msgstr "Přístup k Bluetooth"
 
-#: src/model.js:123
-msgid "Access CAN bus"
-msgstr "Přístup na sběrnici CAN"
+#: src/model.js:131
+msgid "Controller Area Network bus"
+msgstr ""
 
-#: src/model.js:128
-msgid "Access files"
-msgstr "Přístup k souborům"
+#: src/model.js:136
+#, fuzzy
+msgid "All system files"
+msgstr "všechny systémové soubory"
+
+#: src/model.js:141
+#, fuzzy
+msgid "All user files"
+msgstr "všechny uživatelské soubory"
+
+#: src/model.js:146
+#, fuzzy
+msgid "Other files"
+msgstr "všechny uživatelské soubory"
 
 #: src/menu.ui:7
 msgid "Help"
@@ -246,3 +294,18 @@ msgstr "Resetovat oprávnění této aplikace"
 #: src/resetButton.js:43
 msgid "No changes made to this application"
 msgstr "V této aplikaci nebyly provedeny žádné změny"
+
+#~ msgid "Access network"
+#~ msgstr "Přístup k síti"
+
+#~ msgid "Access X11 windowing system (as fallback)"
+#~ msgstr "Přístup k okennímu systému X11 (jako rezerva)"
+
+#~ msgid "Access D-Bus system bus (unrestricted)"
+#~ msgstr "Přístup k systémové sběrnici D-Bus (neomezený)"
+
+#~ msgid "Access CAN bus"
+#~ msgstr "Přístup na sběrnici CAN"
+
+#~ msgid "Access files"
+#~ msgstr "Přístup k souborům"

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatseal\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-01 01:00-0300\n"
+"POT-Creation-Date: 2020-03-03 12:59-0300\n"
 "PO-Revision-Date: 2020-02-01 11:35-0200\n"
 "Last-Translator: Tim Rieck <tim.rieck@gmail.com>\n"
 "Language-Team: none\n"
@@ -56,85 +56,133 @@ msgstr "Anwendungen"
 msgid "No applications found."
 msgstr "Keine Anwendungen gefunden."
 
-#: src/model.js:33
-msgid "Access network"
-msgstr "Zugriff auf das Netzwerk"
+#: src/model.js:24
+msgid "List of subsystems shared with the host system"
+msgstr ""
 
-#: src/model.js:38
-msgid "Access inter-process communications"
+#: src/model.js:25
+msgid "List of well-known sockets available in the sandbox"
+msgstr ""
+
+#: src/model.js:26
+msgid "List of devices available in the sandbox"
+msgstr ""
+
+#: src/model.js:27
+#, fuzzy
+msgid "List of features available to the application"
+msgstr "An dieser Anwendung wurden keine Änderungen vorgenommen"
+
+#: src/model.js:28
+msgid "List of filesystem subsets available to the application"
+msgstr ""
+
+#: src/model.js:41
+msgid "Network"
+msgstr ""
+
+#: src/model.js:46
+#, fuzzy
+msgid "Inter-process communications"
 msgstr "Zugriff zu die prozessübergreifende Kommunikation"
 
-#: src/model.js:43
-msgid "Access X11 windowing system"
+#: src/model.js:51
+#, fuzzy
+msgid "X11 windowing system"
 msgstr "Zugriff auf den X11-Fenstermanager"
 
-#: src/model.js:48
-msgid "Access Wayland windowing system"
+#: src/model.js:56
+#, fuzzy
+msgid "Wayland windowing system"
 msgstr "Zugriff auf den Wayland-Fenstermanager"
 
-#: src/model.js:53
-msgid "Access X11 windowing system (as fallback)"
-msgstr "Zugriff auf den X11-Fenstermanager (als Fallback)"
+#: src/model.js:61
+#, fuzzy
+msgid "Fallback to X11 windowing system"
+msgstr "Zugriff auf den X11-Fenstermanager"
 
-#: src/model.js:58
-msgid "Access PulseAudio sound server"
+#: src/model.js:66
+#, fuzzy
+msgid "PulseAudio sound server"
 msgstr "Zugriff auf den PulseAudio-Soundserver"
 
-#: src/model.js:63
-msgid "Access D-Bus session bus (unrestricted)"
+#: src/model.js:71
+#, fuzzy
+msgid "D-Bus session bus"
 msgstr "Zugriff auf den D-Bus-Sitzungsbus (uneingeschränkt)"
 
-#: src/model.js:68
-msgid "Access D-Bus system bus (unrestricted)"
-msgstr "Zugriff auf den D-Bus-Systembus (uneingeschränkt)"
+#: src/model.js:76
+msgid "D-Bus system bus"
+msgstr ""
 
-#: src/model.js:73
-msgid "Access Secure Shell agent"
+#: src/model.js:81
+#, fuzzy
+msgid "Secure Shell agent"
 msgstr "Zugriff auf den Secure Shell Agent"
 
-#: src/model.js:78
-msgid "Access smart cards"
+#: src/model.js:86
+#, fuzzy
+msgid "Smart cards"
 msgstr "Zugriff auf Smartcards"
 
-#: src/model.js:83
-msgid "Access printing system"
+#: src/model.js:91
+#, fuzzy
+msgid "Printing system"
 msgstr "Zugriff auf die Druckerverwaltung"
 
-#: src/model.js:88
-msgid "Access GPU acceleration"
+#: src/model.js:96
+#, fuzzy
+msgid "GPU acceleration"
 msgstr "Zugriff auf GPU-Beschleunigung"
 
-#: src/model.js:93
-msgid "Access virtualization"
+#: src/model.js:101
+#, fuzzy
+msgid "Virtualization"
 msgstr "Zugriff auf Virtualisierung"
 
-#: src/model.js:98
-msgid "Access shared memory (e.g. JACK sound server)"
+#: src/model.js:106
+#, fuzzy
+msgid "Shared memory (e.g. JACK sound server)"
 msgstr "Zugriff auf gemeinsam genutzten Speicher (z.B. JACK-Soundserver)"
 
-#: src/model.js:103
-msgid "Access all devices (e.g. webcam)"
+#: src/model.js:111
+#, fuzzy
+msgid "All devices (e.g. webcam)"
 msgstr "Zugriff auf alle Geräte (z.B. Webcam)"
 
-#: src/model.js:108
-msgid "Access other syscalls (e.g. ptrace)"
+#: src/model.js:116
+#, fuzzy
+msgid "Development syscalls (e.g. ptrace)"
 msgstr "Zugriff auf andere Systemaufrufe (z.B. ptrace)"
 
-#: src/model.js:113
-msgid "Access programs from other architectures"
+#: src/model.js:121
+#, fuzzy
+msgid "Programs from other architectures"
 msgstr "Zugriff auf Programme anderer Architekturen"
 
-#: src/model.js:118
-msgid "Access Bluetooth"
+#: src/model.js:126
+#, fuzzy
+msgid "Bluetooth"
 msgstr "Zugriff auf Bluetooth"
 
-#: src/model.js:123
-msgid "Access CAN bus"
-msgstr "Zugriff auf den CAN-Bus"
+#: src/model.js:131
+msgid "Controller Area Network bus"
+msgstr ""
 
-#: src/model.js:128
-msgid "Access files"
-msgstr "Zugriff auf Dateien"
+#: src/model.js:136
+#, fuzzy
+msgid "All system files"
+msgstr "alle Systemdateien"
+
+#: src/model.js:141
+#, fuzzy
+msgid "All user files"
+msgstr "alle Benutzerdateien"
+
+#: src/model.js:146
+#, fuzzy
+msgid "Other files"
+msgstr "alle Benutzerdateien"
 
 #: src/menu.ui:7
 msgid "Help"
@@ -246,3 +294,18 @@ msgstr "Berechtigung dieser Anwendung zurücksetzen"
 #: src/resetButton.js:43
 msgid "No changes made to this application"
 msgstr "An dieser Anwendung wurden keine Änderungen vorgenommen"
+
+#~ msgid "Access network"
+#~ msgstr "Zugriff auf das Netzwerk"
+
+#~ msgid "Access X11 windowing system (as fallback)"
+#~ msgstr "Zugriff auf den X11-Fenstermanager (als Fallback)"
+
+#~ msgid "Access D-Bus system bus (unrestricted)"
+#~ msgstr "Zugriff auf den D-Bus-Systembus (uneingeschränkt)"
+
+#~ msgid "Access CAN bus"
+#~ msgstr "Zugriff auf den CAN-Bus"
+
+#~ msgid "Access files"
+#~ msgstr "Zugriff auf Dateien"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatseal\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-01 01:00-0300\n"
+"POT-Creation-Date: 2020-03-03 12:59-0300\n"
 "PO-Revision-Date: 2020-02-01 02:37-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -54,85 +54,133 @@ msgstr "Aplicaciones"
 msgid "No applications found."
 msgstr "No se encontraron aplicaciones."
 
-#: src/model.js:33
-msgid "Access network"
-msgstr "Acceso a la red"
+#: src/model.js:24
+msgid "List of subsystems shared with the host system"
+msgstr ""
 
-#: src/model.js:38
-msgid "Access inter-process communications"
+#: src/model.js:25
+msgid "List of well-known sockets available in the sandbox"
+msgstr ""
+
+#: src/model.js:26
+msgid "List of devices available in the sandbox"
+msgstr ""
+
+#: src/model.js:27
+#, fuzzy
+msgid "List of features available to the application"
+msgstr "No se hicieron cambios a esta aplicación"
+
+#: src/model.js:28
+msgid "List of filesystem subsets available to the application"
+msgstr ""
+
+#: src/model.js:41
+msgid "Network"
+msgstr ""
+
+#: src/model.js:46
+#, fuzzy
+msgid "Inter-process communications"
 msgstr "Acceso a comunicaciones entre procesos"
 
-#: src/model.js:43
-msgid "Access X11 windowing system"
+#: src/model.js:51
+#, fuzzy
+msgid "X11 windowing system"
 msgstr "Acceso al sistema de ventanas X11"
 
-#: src/model.js:48
-msgid "Access Wayland windowing system"
+#: src/model.js:56
+#, fuzzy
+msgid "Wayland windowing system"
 msgstr "Acceso al sistema de ventanas Wayland"
 
-#: src/model.js:53
-msgid "Access X11 windowing system (as fallback)"
-msgstr "Acceso al sistema de ventanas X11 (como respaldo)"
+#: src/model.js:61
+#, fuzzy
+msgid "Fallback to X11 windowing system"
+msgstr "Acceso al sistema de ventanas X11"
 
-#: src/model.js:58
-msgid "Access PulseAudio sound server"
+#: src/model.js:66
+#, fuzzy
+msgid "PulseAudio sound server"
 msgstr "Acceso al servidor de sonido PulseAudio"
 
-#: src/model.js:63
-msgid "Access D-Bus session bus (unrestricted)"
+#: src/model.js:71
+#, fuzzy
+msgid "D-Bus session bus"
 msgstr "Acceso al bus de sesión D-Bus (sin restricciones)"
 
-#: src/model.js:68
-msgid "Access D-Bus system bus (unrestricted)"
-msgstr "Acceso al bus del sistema D-Bus (sin restricciones)"
+#: src/model.js:76
+msgid "D-Bus system bus"
+msgstr ""
 
-#: src/model.js:73
-msgid "Access Secure Shell agent"
+#: src/model.js:81
+#, fuzzy
+msgid "Secure Shell agent"
 msgstr "Acceso al agente Secure Shell"
 
-#: src/model.js:78
-msgid "Access smart cards"
+#: src/model.js:86
+#, fuzzy
+msgid "Smart cards"
 msgstr "Acceso a tarjetas inteligentes"
 
-#: src/model.js:83
-msgid "Access printing system"
+#: src/model.js:91
+#, fuzzy
+msgid "Printing system"
 msgstr "Acceso al sistema de impresión"
 
-#: src/model.js:88
-msgid "Access GPU acceleration"
+#: src/model.js:96
+#, fuzzy
+msgid "GPU acceleration"
 msgstr "Acceso a aceleración de gráficos"
 
-#: src/model.js:93
-msgid "Access virtualization"
+#: src/model.js:101
+#, fuzzy
+msgid "Virtualization"
 msgstr "Acceso a virtualización"
 
-#: src/model.js:98
-msgid "Access shared memory (e.g. JACK sound server)"
+#: src/model.js:106
+#, fuzzy
+msgid "Shared memory (e.g. JACK sound server)"
 msgstr "Acceso a memoria compartida (ej. servidor de sonido JACK)"
 
-#: src/model.js:103
-msgid "Access all devices (e.g. webcam)"
+#: src/model.js:111
+#, fuzzy
+msgid "All devices (e.g. webcam)"
 msgstr "Acceso a todos los dispositivos (ej. cámara web)"
 
-#: src/model.js:108
-msgid "Access other syscalls (e.g. ptrace)"
+#: src/model.js:116
+#, fuzzy
+msgid "Development syscalls (e.g. ptrace)"
 msgstr "Acceso a otras llamadas al sistema (ej. ptrace)"
 
-#: src/model.js:113
-msgid "Access programs from other architectures"
+#: src/model.js:121
+#, fuzzy
+msgid "Programs from other architectures"
 msgstr "Acceso a programas de otras arquitecturas"
 
-#: src/model.js:118
-msgid "Access Bluetooth"
+#: src/model.js:126
+#, fuzzy
+msgid "Bluetooth"
 msgstr "Acceso al Bluetooth"
 
-#: src/model.js:123
-msgid "Access CAN bus"
-msgstr "Acceso al bus CAN"
+#: src/model.js:131
+msgid "Controller Area Network bus"
+msgstr ""
 
-#: src/model.js:128
-msgid "Access files"
-msgstr "Acceso a archivos"
+#: src/model.js:136
+#, fuzzy
+msgid "All system files"
+msgstr "todos los archivos del sistema"
+
+#: src/model.js:141
+#, fuzzy
+msgid "All user files"
+msgstr "todos los archivos de usuario"
+
+#: src/model.js:146
+#, fuzzy
+msgid "Other files"
+msgstr "todos los archivos de usuario"
 
 #: src/menu.ui:7
 msgid "Help"
@@ -244,3 +292,18 @@ msgstr "Restablecer los permisos de esta aplicación"
 #: src/resetButton.js:43
 msgid "No changes made to this application"
 msgstr "No se hicieron cambios a esta aplicación"
+
+#~ msgid "Access network"
+#~ msgstr "Acceso a la red"
+
+#~ msgid "Access X11 windowing system (as fallback)"
+#~ msgstr "Acceso al sistema de ventanas X11 (como respaldo)"
+
+#~ msgid "Access D-Bus system bus (unrestricted)"
+#~ msgstr "Acceso al bus del sistema D-Bus (sin restricciones)"
+
+#~ msgid "Access CAN bus"
+#~ msgstr "Acceso al bus CAN"
+
+#~ msgid "Access files"
+#~ msgstr "Acceso a archivos"

--- a/po/flatseal.pot
+++ b/po/flatseal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatseal\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-01 01:00-0300\n"
+"POT-Creation-Date: 2020-03-03 12:59-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,84 +52,112 @@ msgstr ""
 msgid "No applications found."
 msgstr ""
 
-#: src/model.js:33
-msgid "Access network"
+#: src/model.js:24
+msgid "List of subsystems shared with the host system"
 msgstr ""
 
-#: src/model.js:38
-msgid "Access inter-process communications"
+#: src/model.js:25
+msgid "List of well-known sockets available in the sandbox"
 msgstr ""
 
-#: src/model.js:43
-msgid "Access X11 windowing system"
+#: src/model.js:26
+msgid "List of devices available in the sandbox"
 msgstr ""
 
-#: src/model.js:48
-msgid "Access Wayland windowing system"
+#: src/model.js:27
+msgid "List of features available to the application"
 msgstr ""
 
-#: src/model.js:53
-msgid "Access X11 windowing system (as fallback)"
+#: src/model.js:28
+msgid "List of filesystem subsets available to the application"
 msgstr ""
 
-#: src/model.js:58
-msgid "Access PulseAudio sound server"
+#: src/model.js:41
+msgid "Network"
 msgstr ""
 
-#: src/model.js:63
-msgid "Access D-Bus session bus (unrestricted)"
+#: src/model.js:46
+msgid "Inter-process communications"
 msgstr ""
 
-#: src/model.js:68
-msgid "Access D-Bus system bus (unrestricted)"
+#: src/model.js:51
+msgid "X11 windowing system"
 msgstr ""
 
-#: src/model.js:73
-msgid "Access Secure Shell agent"
+#: src/model.js:56
+msgid "Wayland windowing system"
 msgstr ""
 
-#: src/model.js:78
-msgid "Access smart cards"
+#: src/model.js:61
+msgid "Fallback to X11 windowing system"
 msgstr ""
 
-#: src/model.js:83
-msgid "Access printing system"
+#: src/model.js:66
+msgid "PulseAudio sound server"
 msgstr ""
 
-#: src/model.js:88
-msgid "Access GPU acceleration"
+#: src/model.js:71
+msgid "D-Bus session bus"
 msgstr ""
 
-#: src/model.js:93
-msgid "Access virtualization"
+#: src/model.js:76
+msgid "D-Bus system bus"
 msgstr ""
 
-#: src/model.js:98
-msgid "Access shared memory (e.g. JACK sound server)"
+#: src/model.js:81
+msgid "Secure Shell agent"
 msgstr ""
 
-#: src/model.js:103
-msgid "Access all devices (e.g. webcam)"
+#: src/model.js:86
+msgid "Smart cards"
 msgstr ""
 
-#: src/model.js:108
-msgid "Access other syscalls (e.g. ptrace)"
+#: src/model.js:91
+msgid "Printing system"
 msgstr ""
 
-#: src/model.js:113
-msgid "Access programs from other architectures"
+#: src/model.js:96
+msgid "GPU acceleration"
 msgstr ""
 
-#: src/model.js:118
-msgid "Access Bluetooth"
+#: src/model.js:101
+msgid "Virtualization"
 msgstr ""
 
-#: src/model.js:123
-msgid "Access CAN bus"
+#: src/model.js:106
+msgid "Shared memory (e.g. JACK sound server)"
 msgstr ""
 
-#: src/model.js:128
-msgid "Access files"
+#: src/model.js:111
+msgid "All devices (e.g. webcam)"
+msgstr ""
+
+#: src/model.js:116
+msgid "Development syscalls (e.g. ptrace)"
+msgstr ""
+
+#: src/model.js:121
+msgid "Programs from other architectures"
+msgstr ""
+
+#: src/model.js:126
+msgid "Bluetooth"
+msgstr ""
+
+#: src/model.js:131
+msgid "Controller Area Network bus"
+msgstr ""
+
+#: src/model.js:136
+msgid "All system files"
+msgstr ""
+
+#: src/model.js:141
+msgid "All user files"
+msgstr ""
+
+#: src/model.js:146
+msgid "Other files"
 msgstr ""
 
 #: src/menu.ui:7

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatseal\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-01 01:00-0300\n"
+"POT-Creation-Date: 2020-03-03 12:59-0300\n"
 "PO-Revision-Date: 2020-02-01 03:47-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -54,85 +54,133 @@ msgstr "Alkalmazás"
 msgid "No applications found."
 msgstr "Alkalmazás nem található."
 
-#: src/model.js:33
-msgid "Access network"
-msgstr "A hálózat hozzáférése"
+#: src/model.js:24
+msgid "List of subsystems shared with the host system"
+msgstr ""
 
-#: src/model.js:38
-msgid "Access inter-process communications"
+#: src/model.js:25
+msgid "List of well-known sockets available in the sandbox"
+msgstr ""
+
+#: src/model.js:26
+msgid "List of devices available in the sandbox"
+msgstr ""
+
+#: src/model.js:27
+#, fuzzy
+msgid "List of features available to the application"
+msgstr "Az alkalmazásban nem történt változás"
+
+#: src/model.js:28
+msgid "List of filesystem subsets available to the application"
+msgstr ""
+
+#: src/model.js:41
+msgid "Network"
+msgstr ""
+
+#: src/model.js:46
+#, fuzzy
+msgid "Inter-process communications"
 msgstr "A folyamatok közötti kommunikáció hozzáférése"
 
-#: src/model.js:43
-msgid "Access X11 windowing system"
+#: src/model.js:51
+#, fuzzy
+msgid "X11 windowing system"
 msgstr "A X11 ablakrendszer hozzáférése"
 
-#: src/model.js:48
-msgid "Access Wayland windowing system"
+#: src/model.js:56
+#, fuzzy
+msgid "Wayland windowing system"
 msgstr "A Wayland ablakrendszer hozzáférése"
 
-#: src/model.js:53
-msgid "Access X11 windowing system (as fallback)"
-msgstr "A X11 ablakrendszer hozzáférése (tartalékként)"
+#: src/model.js:61
+#, fuzzy
+msgid "Fallback to X11 windowing system"
+msgstr "A X11 ablakrendszer hozzáférése"
 
-#: src/model.js:58
-msgid "Access PulseAudio sound server"
+#: src/model.js:66
+#, fuzzy
+msgid "PulseAudio sound server"
 msgstr "A PulseAudio hangkiszolgáló hozzáférése"
 
-#: src/model.js:63
-msgid "Access D-Bus session bus (unrestricted)"
+#: src/model.js:71
+#, fuzzy
+msgid "D-Bus session bus"
 msgstr "A D-Bus munkamenet busz hozzáférése (korlátlan)"
 
-#: src/model.js:68
-msgid "Access D-Bus system bus (unrestricted)"
-msgstr "A D-Bus rendszer busz hozzáférése (korlátlan)"
+#: src/model.js:76
+msgid "D-Bus system bus"
+msgstr ""
 
-#: src/model.js:73
-msgid "Access Secure Shell agent"
+#: src/model.js:81
+#, fuzzy
+msgid "Secure Shell agent"
 msgstr "A Secure Shell ügynök hozzáférése"
 
-#: src/model.js:78
-msgid "Access smart cards"
+#: src/model.js:86
+#, fuzzy
+msgid "Smart cards"
 msgstr "Az intelligens kártyák hozzáférése"
 
-#: src/model.js:83
-msgid "Access printing system"
+#: src/model.js:91
+#, fuzzy
+msgid "Printing system"
 msgstr "A nyomtatási rendszer hozzáférése"
 
-#: src/model.js:88
-msgid "Access GPU acceleration"
+#: src/model.js:96
+#, fuzzy
+msgid "GPU acceleration"
 msgstr "GPU gyorsítási hozzáférése"
 
-#: src/model.js:93
-msgid "Access virtualization"
+#: src/model.js:101
+#, fuzzy
+msgid "Virtualization"
 msgstr "A virtualizáció hozzáférése"
 
-#: src/model.js:98
-msgid "Access shared memory (e.g. JACK sound server)"
+#: src/model.js:106
+#, fuzzy
+msgid "Shared memory (e.g. JACK sound server)"
 msgstr "A megosztott memória hozzáférése (pl. JACK hang kiszolgáló)"
 
-#: src/model.js:103
-msgid "Access all devices (e.g. webcam)"
+#: src/model.js:111
+#, fuzzy
+msgid "All devices (e.g. webcam)"
 msgstr "Az összes eszköz hozzáférése (pl. webkamera)"
 
-#: src/model.js:108
-msgid "Access other syscalls (e.g. ptrace)"
+#: src/model.js:116
+#, fuzzy
+msgid "Development syscalls (e.g. ptrace)"
 msgstr "Más rendszerhívások hozzáférése (pl. ptrace)"
 
-#: src/model.js:113
-msgid "Access programs from other architectures"
+#: src/model.js:121
+#, fuzzy
+msgid "Programs from other architectures"
 msgstr "Más architektúrák programjaihoz hozzáférése"
 
-#: src/model.js:118
-msgid "Access Bluetooth"
+#: src/model.js:126
+#, fuzzy
+msgid "Bluetooth"
 msgstr "Bluetooth hozzáférése"
 
-#: src/model.js:123
-msgid "Access CAN bus"
-msgstr "A CAN-busz hozzáférése"
+#: src/model.js:131
+msgid "Controller Area Network bus"
+msgstr ""
 
-#: src/model.js:128
-msgid "Access files"
-msgstr "Hozzáférés a fájlokhoz"
+#: src/model.js:136
+#, fuzzy
+msgid "All system files"
+msgstr "az összes rendszerfájl"
+
+#: src/model.js:141
+#, fuzzy
+msgid "All user files"
+msgstr "minden felhasználói fájl"
+
+#: src/model.js:146
+#, fuzzy
+msgid "Other files"
+msgstr "minden felhasználói fájl"
 
 #: src/menu.ui:7
 msgid "Help"
@@ -244,3 +292,18 @@ msgstr "Alkalmazás engedélyek alaphelyzetbe állítása"
 #: src/resetButton.js:43
 msgid "No changes made to this application"
 msgstr "Az alkalmazásban nem történt változás"
+
+#~ msgid "Access network"
+#~ msgstr "A hálózat hozzáférése"
+
+#~ msgid "Access X11 windowing system (as fallback)"
+#~ msgstr "A X11 ablakrendszer hozzáférése (tartalékként)"
+
+#~ msgid "Access D-Bus system bus (unrestricted)"
+#~ msgstr "A D-Bus rendszer busz hozzáférése (korlátlan)"
+
+#~ msgid "Access CAN bus"
+#~ msgstr "A CAN-busz hozzáférése"
+
+#~ msgid "Access files"
+#~ msgstr "Hozzáférés a fájlokhoz"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatseal\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-01 01:00-0300\n"
+"POT-Creation-Date: 2020-03-03 12:59-0300\n"
 "PO-Revision-Date: 2020-02-13 09:12+0100\n"
 "Last-Translator: Milo Casagrande <milo@milo.name>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -56,85 +56,133 @@ msgstr "Applicazioni"
 msgid "No applications found."
 msgstr "Non è stata trovata alcuna applicazione."
 
-#: src/model.js:33
-msgid "Access network"
-msgstr "Accesso alla rete"
+#: src/model.js:24
+msgid "List of subsystems shared with the host system"
+msgstr ""
 
-#: src/model.js:38
-msgid "Access inter-process communications"
+#: src/model.js:25
+msgid "List of well-known sockets available in the sandbox"
+msgstr ""
+
+#: src/model.js:26
+msgid "List of devices available in the sandbox"
+msgstr ""
+
+#: src/model.js:27
+#, fuzzy
+msgid "List of features available to the application"
+msgstr "Nessuna modifica apportata a questa applicazione"
+
+#: src/model.js:28
+msgid "List of filesystem subsets available to the application"
+msgstr ""
+
+#: src/model.js:41
+msgid "Network"
+msgstr ""
+
+#: src/model.js:46
+#, fuzzy
+msgid "Inter-process communications"
 msgstr "Accesso alle comunicazioni intra-processi"
 
-#: src/model.js:43
-msgid "Access X11 windowing system"
+#: src/model.js:51
+#, fuzzy
+msgid "X11 windowing system"
 msgstr "Accesso al sistema X11"
 
-#: src/model.js:48
-msgid "Access Wayland windowing system"
+#: src/model.js:56
+#, fuzzy
+msgid "Wayland windowing system"
 msgstr "Accesso al sistema Wayland"
 
-#: src/model.js:53
-msgid "Access X11 windowing system (as fallback)"
-msgstr "Accesso al sistema X11 (come ripiego)"
+#: src/model.js:61
+#, fuzzy
+msgid "Fallback to X11 windowing system"
+msgstr "Accesso al sistema X11"
 
-#: src/model.js:58
-msgid "Access PulseAudio sound server"
+#: src/model.js:66
+#, fuzzy
+msgid "PulseAudio sound server"
 msgstr "Accesso al server audio PulseAudio"
 
-#: src/model.js:63
-msgid "Access D-Bus session bus (unrestricted)"
+#: src/model.js:71
+#, fuzzy
+msgid "D-Bus session bus"
 msgstr "Accesso al bus di sessione D-Bus (senza restrizioni)"
 
-#: src/model.js:68
-msgid "Access D-Bus system bus (unrestricted)"
-msgstr "Accesso al bus di sistema D-Bus (senza restrizioni)"
+#: src/model.js:76
+msgid "D-Bus system bus"
+msgstr ""
 
-#: src/model.js:73
-msgid "Access Secure Shell agent"
+#: src/model.js:81
+#, fuzzy
+msgid "Secure Shell agent"
 msgstr "Accesso all'agente Secure Shell"
 
-#: src/model.js:78
-msgid "Access smart cards"
+#: src/model.js:86
+#, fuzzy
+msgid "Smart cards"
 msgstr "Accesso alle smart card"
 
-#: src/model.js:83
-msgid "Access printing system"
+#: src/model.js:91
+#, fuzzy
+msgid "Printing system"
 msgstr "Accesso al sistema di stampa"
 
-#: src/model.js:88
-msgid "Access GPU acceleration"
+#: src/model.js:96
+#, fuzzy
+msgid "GPU acceleration"
 msgstr "Accesso all'accelerazione tramite GPU"
 
-#: src/model.js:93
-msgid "Access virtualization"
+#: src/model.js:101
+#, fuzzy
+msgid "Virtualization"
 msgstr "Accesso alla virtualizzazione"
 
-#: src/model.js:98
-msgid "Access shared memory (e.g. JACK sound server)"
+#: src/model.js:106
+#, fuzzy
+msgid "Shared memory (e.g. JACK sound server)"
 msgstr "Accesso alla memoria condivisa (per esempio server audio JACK)"
 
-#: src/model.js:103
-msgid "Access all devices (e.g. webcam)"
+#: src/model.js:111
+#, fuzzy
+msgid "All devices (e.g. webcam)"
 msgstr "Accesso a tutti i dispositivi (per esempio fotocamera)"
 
-#: src/model.js:108
-msgid "Access other syscalls (e.g. ptrace)"
+#: src/model.js:116
+#, fuzzy
+msgid "Development syscalls (e.g. ptrace)"
 msgstr "Accesso ad altre chiamate di sistema (per esempio ptrace)"
 
-#: src/model.js:113
-msgid "Access programs from other architectures"
+#: src/model.js:121
+#, fuzzy
+msgid "Programs from other architectures"
 msgstr "Accesso ai programmi da altre architetture"
 
-#: src/model.js:118
-msgid "Access Bluetooth"
+#: src/model.js:126
+#, fuzzy
+msgid "Bluetooth"
 msgstr "Accesso al Bluetooth"
 
-#: src/model.js:123
-msgid "Access CAN bus"
-msgstr "Accesso al bus CAN"
+#: src/model.js:131
+msgid "Controller Area Network bus"
+msgstr ""
 
-#: src/model.js:128
-msgid "Access files"
-msgstr "Accesso ai file"
+#: src/model.js:136
+#, fuzzy
+msgid "All system files"
+msgstr "tutti i file di sistema"
+
+#: src/model.js:141
+#, fuzzy
+msgid "All user files"
+msgstr "tutti i file utente"
+
+#: src/model.js:146
+#, fuzzy
+msgid "Other files"
+msgstr "tutti i file utente"
 
 #: src/menu.ui:7
 msgid "Help"
@@ -246,3 +294,18 @@ msgstr "Ripristina i permessi di questa applicazione"
 #: src/resetButton.js:43
 msgid "No changes made to this application"
 msgstr "Nessuna modifica apportata a questa applicazione"
+
+#~ msgid "Access network"
+#~ msgstr "Accesso alla rete"
+
+#~ msgid "Access X11 windowing system (as fallback)"
+#~ msgstr "Accesso al sistema X11 (come ripiego)"
+
+#~ msgid "Access D-Bus system bus (unrestricted)"
+#~ msgstr "Accesso al bus di sistema D-Bus (senza restrizioni)"
+
+#~ msgid "Access CAN bus"
+#~ msgstr "Accesso al bus CAN"
+
+#~ msgid "Access files"
+#~ msgstr "Accesso ai file"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatseal\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-01 01:00-0300\n"
+"POT-Creation-Date: 2020-03-03 12:59-0300\n"
 "PO-Revision-Date: 2020-02-09 18:03+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -55,85 +55,133 @@ msgstr "Toepassingen"
 msgid "No applications found."
 msgstr "Geen toepassingen aangetroffen."
 
-#: src/model.js:33
-msgid "Access network"
-msgstr "Toegang tot het netwerk"
+#: src/model.js:24
+msgid "List of subsystems shared with the host system"
+msgstr ""
 
-#: src/model.js:38
-msgid "Access inter-process communications"
+#: src/model.js:25
+msgid "List of well-known sockets available in the sandbox"
+msgstr ""
+
+#: src/model.js:26
+msgid "List of devices available in the sandbox"
+msgstr ""
+
+#: src/model.js:27
+#, fuzzy
+msgid "List of features available to the application"
+msgstr "Geen wijzigingen aangebracht aan deze toepassing"
+
+#: src/model.js:28
+msgid "List of filesystem subsets available to the application"
+msgstr ""
+
+#: src/model.js:41
+msgid "Network"
+msgstr ""
+
+#: src/model.js:46
+#, fuzzy
+msgid "Inter-process communications"
 msgstr "Toegang tot procesuitwisselingscommunicatie"
 
-#: src/model.js:43
-msgid "Access X11 windowing system"
+#: src/model.js:51
+#, fuzzy
+msgid "X11 windowing system"
 msgstr "Toegang tot het X11-venstersysteem"
 
-#: src/model.js:48
-msgid "Access Wayland windowing system"
+#: src/model.js:56
+#, fuzzy
+msgid "Wayland windowing system"
 msgstr "Toegang tot het Wayland-venstersysteem"
 
-#: src/model.js:53
-msgid "Access X11 windowing system (as fallback)"
-msgstr "Toegang tot het X11-venstersysteem (terugvallen op)"
+#: src/model.js:61
+#, fuzzy
+msgid "Fallback to X11 windowing system"
+msgstr "Toegang tot het X11-venstersysteem"
 
-#: src/model.js:58
-msgid "Access PulseAudio sound server"
+#: src/model.js:66
+#, fuzzy
+msgid "PulseAudio sound server"
 msgstr "Toegang tot de PulseAudio-geluidsserver"
 
-#: src/model.js:63
-msgid "Access D-Bus session bus (unrestricted)"
+#: src/model.js:71
+#, fuzzy
+msgid "D-Bus session bus"
 msgstr "Toegang tot de D-Bus-sessiebus (ongelimiteerd)"
 
-#: src/model.js:68
-msgid "Access D-Bus system bus (unrestricted)"
-msgstr "Toegang tot de D-Bus-systeembus (ongelimiteerd)"
+#: src/model.js:76
+msgid "D-Bus system bus"
+msgstr ""
 
-#: src/model.js:73
-msgid "Access Secure Shell agent"
+#: src/model.js:81
+#, fuzzy
+msgid "Secure Shell agent"
 msgstr "Toegang tot de Secure Shell-agent"
 
-#: src/model.js:78
-msgid "Access smart cards"
+#: src/model.js:86
+#, fuzzy
+msgid "Smart cards"
 msgstr "Toegang tot smartcards"
 
-#: src/model.js:83
-msgid "Access printing system"
+#: src/model.js:91
+#, fuzzy
+msgid "Printing system"
 msgstr "Toegang tot het afdruksysteem"
 
-#: src/model.js:88
-msgid "Access GPU acceleration"
+#: src/model.js:96
+#, fuzzy
+msgid "GPU acceleration"
 msgstr "Toegang tot GPU-versnelling"
 
-#: src/model.js:93
-msgid "Access virtualization"
+#: src/model.js:101
+#, fuzzy
+msgid "Virtualization"
 msgstr "Toegang tot virtualisatie"
 
-#: src/model.js:98
-msgid "Access shared memory (e.g. JACK sound server)"
+#: src/model.js:106
+#, fuzzy
+msgid "Shared memory (e.g. JACK sound server)"
 msgstr "Toegang tot gedeeld geheugen (bijv. JACK-geluidsserver)"
 
-#: src/model.js:103
-msgid "Access all devices (e.g. webcam)"
+#: src/model.js:111
+#, fuzzy
+msgid "All devices (e.g. webcam)"
 msgstr "Toegang tot alle apparaten (bijv. webcam)"
 
-#: src/model.js:108
-msgid "Access other syscalls (e.g. ptrace)"
+#: src/model.js:116
+#, fuzzy
+msgid "Development syscalls (e.g. ptrace)"
 msgstr "Toegang tot andere systeemaanroepingen (bijv. ptrace)"
 
-#: src/model.js:113
-msgid "Access programs from other architectures"
+#: src/model.js:121
+#, fuzzy
+msgid "Programs from other architectures"
 msgstr "Toegang tot toepassingen van andere architecturen"
 
-#: src/model.js:118
-msgid "Access Bluetooth"
+#: src/model.js:126
+#, fuzzy
+msgid "Bluetooth"
 msgstr "Toegang tot Bluetooth"
 
-#: src/model.js:123
-msgid "Access CAN bus"
-msgstr "Toegang tot de CAN-bus"
+#: src/model.js:131
+msgid "Controller Area Network bus"
+msgstr ""
 
-#: src/model.js:128
-msgid "Access files"
-msgstr "Toegang tot bestanden"
+#: src/model.js:136
+#, fuzzy
+msgid "All system files"
+msgstr "alle systeembestanden"
+
+#: src/model.js:141
+#, fuzzy
+msgid "All user files"
+msgstr "alle gebruikersbestanden"
+
+#: src/model.js:146
+#, fuzzy
+msgid "Other files"
+msgstr "alle gebruikersbestanden"
 
 #: src/menu.ui:7
 msgid "Help"
@@ -245,3 +293,18 @@ msgstr "Herstel alle toepassingsmachtigingen"
 #: src/resetButton.js:43
 msgid "No changes made to this application"
 msgstr "Geen wijzigingen aangebracht aan deze toepassing"
+
+#~ msgid "Access network"
+#~ msgstr "Toegang tot het netwerk"
+
+#~ msgid "Access X11 windowing system (as fallback)"
+#~ msgstr "Toegang tot het X11-venstersysteem (terugvallen op)"
+
+#~ msgid "Access D-Bus system bus (unrestricted)"
+#~ msgstr "Toegang tot de D-Bus-systeembus (ongelimiteerd)"
+
+#~ msgid "Access CAN bus"
+#~ msgstr "Toegang tot de CAN-bus"
+
+#~ msgid "Access files"
+#~ msgstr "Toegang tot bestanden"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatseal\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-01 01:00-0300\n"
+"POT-Creation-Date: 2020-03-03 12:59-0300\n"
 "PO-Revision-Date: 2020-02-05 14:06-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -54,85 +54,133 @@ msgstr "Aplicativos"
 msgid "No applications found."
 msgstr "Nenhum aplicativo encontrado."
 
-#: src/model.js:33
-msgid "Access network"
-msgstr "Acesso à rede"
+#: src/model.js:24
+msgid "List of subsystems shared with the host system"
+msgstr ""
 
-#: src/model.js:38
-msgid "Access inter-process communications"
+#: src/model.js:25
+msgid "List of well-known sockets available in the sandbox"
+msgstr ""
+
+#: src/model.js:26
+msgid "List of devices available in the sandbox"
+msgstr ""
+
+#: src/model.js:27
+#, fuzzy
+msgid "List of features available to the application"
+msgstr "Nenhuma alteração feita neste aplicativo"
+
+#: src/model.js:28
+msgid "List of filesystem subsets available to the application"
+msgstr ""
+
+#: src/model.js:41
+msgid "Network"
+msgstr ""
+
+#: src/model.js:46
+#, fuzzy
+msgid "Inter-process communications"
 msgstr "Acesso a comunicações entre processos"
 
-#: src/model.js:43
-msgid "Access X11 windowing system"
+#: src/model.js:51
+#, fuzzy
+msgid "X11 windowing system"
 msgstr "Acesso ao sistema de janelas X11"
 
-#: src/model.js:48
-msgid "Access Wayland windowing system"
+#: src/model.js:56
+#, fuzzy
+msgid "Wayland windowing system"
 msgstr "Acesso ao sistema de janelas Wayland"
 
-#: src/model.js:53
-msgid "Access X11 windowing system (as fallback)"
-msgstr "Acesso ao sistema de janelas X11 (como substituto)"
+#: src/model.js:61
+#, fuzzy
+msgid "Fallback to X11 windowing system"
+msgstr "Acesso ao sistema de janelas X11"
 
-#: src/model.js:58
-msgid "Access PulseAudio sound server"
+#: src/model.js:66
+#, fuzzy
+msgid "PulseAudio sound server"
 msgstr "Acesso ao servidor de som PulseAudio"
 
-#: src/model.js:63
-msgid "Access D-Bus session bus (unrestricted)"
+#: src/model.js:71
+#, fuzzy
+msgid "D-Bus session bus"
 msgstr "Acesso ao barramento de sessão do D-Bus (sem restrições)"
 
-#: src/model.js:68
-msgid "Access D-Bus system bus (unrestricted)"
-msgstr "Acesso ao barramento do sistema D-Bus (sem restrições)"
+#: src/model.js:76
+msgid "D-Bus system bus"
+msgstr ""
 
-#: src/model.js:73
-msgid "Access Secure Shell agent"
+#: src/model.js:81
+#, fuzzy
+msgid "Secure Shell agent"
 msgstr "Acesso ao agente Secure Shell"
 
-#: src/model.js:78
-msgid "Access smart cards"
+#: src/model.js:86
+#, fuzzy
+msgid "Smart cards"
 msgstr "Acesso a cartões inteligentes"
 
-#: src/model.js:83
-msgid "Access printing system"
+#: src/model.js:91
+#, fuzzy
+msgid "Printing system"
 msgstr "Acesso ao sistema de impressão"
 
-#: src/model.js:88
-msgid "Access GPU acceleration"
+#: src/model.js:96
+#, fuzzy
+msgid "GPU acceleration"
 msgstr "Acesso à aceleração de GPU"
 
-#: src/model.js:93
-msgid "Access virtualization"
+#: src/model.js:101
+#, fuzzy
+msgid "Virtualization"
 msgstr "Acesso à virtualização"
 
-#: src/model.js:98
-msgid "Access shared memory (e.g. JACK sound server)"
+#: src/model.js:106
+#, fuzzy
+msgid "Shared memory (e.g. JACK sound server)"
 msgstr "Acesso à memória compartilhada (p. ex. servidor de som JACK)"
 
-#: src/model.js:103
-msgid "Access all devices (e.g. webcam)"
+#: src/model.js:111
+#, fuzzy
+msgid "All devices (e.g. webcam)"
 msgstr "Acesso a todos os dispositivos (p. ex. webcam)"
 
-#: src/model.js:108
-msgid "Access other syscalls (e.g. ptrace)"
+#: src/model.js:116
+#, fuzzy
+msgid "Development syscalls (e.g. ptrace)"
 msgstr "Acesso a outras chamadas do sistema (p. ex. ptrace)"
 
-#: src/model.js:113
-msgid "Access programs from other architectures"
+#: src/model.js:121
+#, fuzzy
+msgid "Programs from other architectures"
 msgstr "Acesso a programas de outras arquiteturas"
 
-#: src/model.js:118
-msgid "Access Bluetooth"
+#: src/model.js:126
+#, fuzzy
+msgid "Bluetooth"
 msgstr "Acesso ao Bluetooth"
 
-#: src/model.js:123
-msgid "Access CAN bus"
-msgstr "Acesso ao barramento CAN"
+#: src/model.js:131
+msgid "Controller Area Network bus"
+msgstr ""
 
-#: src/model.js:128
-msgid "Access files"
-msgstr "Acesso a arquivos"
+#: src/model.js:136
+#, fuzzy
+msgid "All system files"
+msgstr "todos os arquivos do sistema"
+
+#: src/model.js:141
+#, fuzzy
+msgid "All user files"
+msgstr "todos os arquivos do usuário"
+
+#: src/model.js:146
+#, fuzzy
+msgid "Other files"
+msgstr "todos os arquivos do usuário"
 
 #: src/menu.ui:7
 msgid "Help"
@@ -244,3 +292,18 @@ msgstr "Restaurar as permissões deste aplicativo"
 #: src/resetButton.js:43
 msgid "No changes made to this application"
 msgstr "Nenhuma alteração feita neste aplicativo"
+
+#~ msgid "Access network"
+#~ msgstr "Acesso à rede"
+
+#~ msgid "Access X11 windowing system (as fallback)"
+#~ msgstr "Acesso ao sistema de janelas X11 (como substituto)"
+
+#~ msgid "Access D-Bus system bus (unrestricted)"
+#~ msgstr "Acesso ao barramento do sistema D-Bus (sem restrições)"
+
+#~ msgid "Access CAN bus"
+#~ msgstr "Acesso ao barramento CAN"
+
+#~ msgid "Access files"
+#~ msgstr "Acesso a arquivos"

--- a/src/application.css
+++ b/src/application.css
@@ -28,45 +28,59 @@
 .permissions .box {
     padding-left: 10px;
     padding-right: 10px;
-    margin-top: 25px;
     margin-bottom: 25px;
 }
 
-.permissions .row {
-   margin-top: 10px;
-   background-color: @theme_base_color;
-   border-style: solid;
-   border-width: 0.2px;
+.permissions .group {
+    margin-top: 25px;
+    margin-bottom: 10px;
+}
+.permissions .group .title {
+    font-weight: bold;
+}
+.permissions .group .description {
+    margin-top: 5px;
+    color: @insensitive_fg_color;
 }
 
-.permissions .description,
-.permissions .permission {
+.permissions .row {
+    background-color: @theme_base_color;
+    border-style: solid;
+    border-width: 0.2px;
+}
+
+.permissions .row.shared ~ .shared,
+.permissions .row.sockets ~ .sockets,
+.permissions .row.devices ~ .devices,
+.permissions .row.features ~ .features,
+.permissions .row.filesystems ~ .filesystems {
+    border-style: none solid solid solid;
+}
+
+.permissions .row .description,
+.permissions .row .permission {
    margin-left: 15px;
 }
 
-.permissions .description {
-    font-weight: bold;
-}
-
-.permissions .permission {
+.permissions .row .permission {
     font-style: italic;
     font-size: small;
 }
 
-.permissions .content {
+.permissions .row .content {
    margin-left: 15px;
    margin-right: 15px;
 }
 
-.permissions .frame {
+.permissions .row .frame {
     border-width: 0px;
 }
 
-.permissions .toolbox {
+.permissions .row .toolbox {
     margin-right: 15px;
 }
 
-.permissions .content .path {
+.permissions .row .content .path {
     color: @theme_fg_color;
     border-style: solid;
     border-width: 0.5px;
@@ -75,48 +89,45 @@
     margin-bottom: 10px;
 }
 
-.permissions .content .path entry,
-.permissions .content .path button,
-.permissions .content .path button:hover,
-.permissions .content .path button:focus,
-.permissions .content .path button:selected {
+.permissions .row .content .path.read-only,
+.permissions .row .content .path.create,
+.permissions .row .content .path.read-write  {
+    background-color: @theme_bg_color;
+}
+
+.permissions .row .content .path entry,
+.permissions .row .content .path button,
+.permissions .row .content .path button:hover,
+.permissions .row .content .path button:focus,
+.permissions .row .content .path button:selected {
    background-image: none;
    background-color: transparent;
    border: none;
    box-shadow: none;
 }
 
-.permissions .content .path .info {
+.permissions .row .content .path .info {
     margin-left: 10px;
     color: @theme_selected_bg_color;
     background-color: transparent;
     background-image: -gtk-icontheme("dialog-question-symbolic");
 }
 
-.permissions .content .path.not-valid .info {
+.permissions .row .content .path.not-valid .info {
     color: @warning_color;
     background-image: -gtk-icontheme("dialog-warning-symbolic");
 }
 
-.permissions .content .path button image {
+.permissions .row .content .path button image {
     color: @theme_fg_color;
 }
 
-.permissions .content .path button image:disabled {
+.permissions .row .content .path button image:disabled {
     color: @insensitive_fg_color;
 }
 
-.permissions .content .path.read-only {
-    background-color: @theme_bg_color;
-}
-
-.permissions .content .path.create,
-.permissions .content .path.read-write  {
-    background-color: @theme_bg_color;
-}
-
 /* XXX Navigate through xdg options without the popup  */
-.permissions .content .path window {
+.permissions .row .content .path window {
    opacity: 0;
    background-image: none;
    background-color: transparent;

--- a/src/com.github.tchx84.Flatseal.data.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.data.gresource.xml
@@ -4,6 +4,7 @@
     <file>aboutDialog.ui</file>
     <file>application.css</file>
     <file>applicationRow.ui</file>
+    <file>groupRow.ui</file>
     <file>menu.ui</file>
     <file>pathRow.ui</file>
     <file>pathsViewer.ui</file>

--- a/src/com.github.tchx84.Flatseal.src.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.src.gresource.xml
@@ -4,6 +4,7 @@
     <file>aboutDialog.js</file>
     <file>application.js</file>
     <file>applicationRow.js</file>
+    <file>groupRow.js</file>
     <file>main.js</file>
     <file>model.js</file>
     <file>pathRow.js</file>

--- a/src/groupRow.js
+++ b/src/groupRow.js
@@ -1,0 +1,36 @@
+/* groupRow.js
+ *
+ * Copyright 2020 Martin Abente Lahaye
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const {GObject, Gtk} = imports.gi;
+
+
+var FlatsealGroupRow = GObject.registerClass({
+    GTypeName: 'FlatsealGroupRow',
+    Template: 'resource:///com/github/tchx84/Flatseal/groupRow.ui',
+    InternalChildren: ['title', 'description'],
+}, class FlatsealGroupRow extends Gtk.Box {
+    _init(title, description) {
+        super._init({});
+        this._title.set_label(this.constructor._formatTitle(title));
+        this._description.set_label(description);
+    }
+
+    static _formatTitle(title) {
+        return title.replace(/^\w/, c => c.toUpperCase());
+    }
+});

--- a/src/groupRow.ui
+++ b/src/groupRow.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="FlatsealGroupRow" parent="GtkBox">
+    <property name="height_request">60</property>
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel" id="title">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">end</property>
+        <property name="ellipsize">end</property>
+        <property name="single_line_mode">True</property>
+        <style>
+          <class name="title"/>
+        </style>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="description">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">start</property>
+        <property name="ellipsize">end</property>
+        <property name="single_line_mode">True</property>
+        <style>
+          <class name="description"/>
+        </style>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <style>
+      <class name="group"/>
+    </style>
+  </template>
+</interface>

--- a/src/model.js
+++ b/src/model.js
@@ -110,16 +110,6 @@ var FlatsealModel = GObject.registerClass({
             '0.6.6',
             _('All devices (e.g. webcam)'),
             _propFlags, false),
-        'filesystems-host': GObject.ParamSpec.boolean(
-            'filesystems-host',
-            '0.4.0',
-            _('Access all system directories (unrestricted)'),
-            _propFlags, false),
-        'filesystems-home': GObject.ParamSpec.boolean(
-            'filesystems-home',
-            '0.4.0',
-            _('Access home directory (unrestricted)'),
-            _propFlags, false),
         'features-devel': GObject.ParamSpec.boolean(
             'features-devel',
             '0.6.10',
@@ -140,10 +130,20 @@ var FlatsealModel = GObject.registerClass({
             '1.0.3',
             _('Controller Area Network bus'),
             _propFlags, false),
+        'filesystems-host': GObject.ParamSpec.boolean(
+            'filesystems-host',
+            '0.4.0',
+            _('All system files'),
+            _propFlags, false),
+        'filesystems-home': GObject.ParamSpec.boolean(
+            'filesystems-home',
+            '0.4.0',
+            _('All user files'),
+            _propFlags, false),
         'filesystems-custom': GObject.ParamSpec.string(
             'filesystems-custom',
             '0.6.14',
-            _('Files'),
+            _('Other files'),
             _propFlags, ''),
     },
     Signals: {

--- a/src/model.js
+++ b/src/model.js
@@ -20,6 +20,14 @@ const {GObject, GLib, Gio} = imports.gi;
 
 const _propFlags = GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT;
 
+const _groupDescriptions = {
+    shared: _('List of subsystems shared with the host system'),
+    sockets: _('List of well-known sockets available in the sandbox'),
+    devices: _('List of devices available in the sandbox'),
+    features: _('List of features available to the application'),
+    filesystems: _('List of filesystem subsets available to the application'),
+};
+
 var GROUP = 'Context';
 var DELAY = 500;
 
@@ -30,102 +38,102 @@ var FlatsealModel = GObject.registerClass({
         'shared-network': GObject.ParamSpec.boolean(
             'shared-network',
             '0.4.0',
-            _('Access network'),
+            _('Network'),
             _propFlags, false),
         'shared-ipc': GObject.ParamSpec.boolean(
             'shared-ipc',
             '0.4.0',
-            _('Access inter-process communications'),
+            _('Inter-process communications'),
             _propFlags, false),
         'sockets-x11': GObject.ParamSpec.boolean(
             'sockets-x11',
             '0.4.0',
-            _('Access X11 windowing system'),
+            _('X11 windowing system'),
             _propFlags, false),
         'sockets-wayland': GObject.ParamSpec.boolean(
             'sockets-wayland',
             '0.4.0',
-            _('Access Wayland windowing system'),
+            _('Wayland windowing system'),
             _propFlags, false),
         'sockets-fallback-x11': GObject.ParamSpec.boolean(
             'sockets-fallback-x11',
             '0.11.1',
-            _('Access X11 windowing system (as fallback)'),
+            _('Fallback to X11 windowing system'),
             _propFlags, false),
         'sockets-pulseaudio': GObject.ParamSpec.boolean(
             'sockets-pulseaudio',
             '0.4.0',
-            _('Access PulseAudio sound server'),
+            _('PulseAudio sound server'),
             _propFlags, false),
         'sockets-session-bus': GObject.ParamSpec.boolean(
             'sockets-session-bus',
             '0.4.0',
-            _('Access D-Bus session bus (unrestricted)'),
+            _('D-Bus session bus'),
             _propFlags, false),
         'sockets-system-bus': GObject.ParamSpec.boolean(
             'sockets-system-bus',
             '0.4.0',
-            _('Access D-Bus system bus (unrestricted)'),
+            _('D-Bus system bus'),
             _propFlags, false),
         'sockets-ssh-auth': GObject.ParamSpec.boolean(
             'sockets-ssh-auth',
             '0.99.1',
-            _('Access Secure Shell agent'),
+            _('Secure Shell agent'),
             _propFlags, false),
         'sockets-pcsc': GObject.ParamSpec.boolean(
             'sockets-pcsc',
             '1.3.2',
-            _('Access smart cards'),
+            _('Smart cards'),
             _propFlags, false),
         'sockets-cups': GObject.ParamSpec.boolean(
             'sockets-cups',
             '1.5.2',
-            _('Access printing system'),
+            _('Printing system'),
             _propFlags, false),
         'devices-dri': GObject.ParamSpec.boolean(
             'devices-dri',
             '0.4.0',
-            _('Access GPU acceleration'),
+            _('GPU acceleration'),
             _propFlags, false),
         'devices-kvm': GObject.ParamSpec.boolean(
             'devices-kvm',
             '0.6.12',
-            _('Access virtualization'),
+            _('Virtualization'),
             _propFlags, false),
         'devices-shm': GObject.ParamSpec.boolean(
             'devices-shm',
             '1.6.1',
-            _('Access shared memory (e.g. JACK sound server)'),
+            _('Shared memory (e.g. JACK sound server)'),
             _propFlags, false),
         'devices-all': GObject.ParamSpec.boolean(
             'devices-all',
             '0.6.6',
-            _('Access all devices (e.g. webcam)'),
+            _('All devices (e.g. webcam)'),
             _propFlags, false),
         'features-devel': GObject.ParamSpec.boolean(
             'features-devel',
             '0.6.10',
-            _('Access other syscalls (e.g. ptrace)'),
+            _('Development syscalls (e.g. ptrace)'),
             _propFlags, false),
         'features-multiarch': GObject.ParamSpec.boolean(
             'features-multiarch',
             '0.6.12',
-            _('Access programs from other architectures'),
+            _('Programs from other architectures'),
             _propFlags, false),
         'features-bluetooth': GObject.ParamSpec.boolean(
             'features-bluetooth',
             '0.11.8',
-            _('Access Bluetooth'),
+            _('Bluetooth'),
             _propFlags, false),
         'features-canbus': GObject.ParamSpec.boolean(
             'features-canbus',
             '1.0.3',
-            _('Access CAN bus'),
+            _('Controller Area Network bus'),
             _propFlags, false),
         'filesystems-custom': GObject.ParamSpec.string(
             'filesystems-custom',
             '0.6.14',
-            _('Access files'),
+            _('Files'),
             _propFlags, ''),
     },
     Signals: {
@@ -487,6 +495,7 @@ var FlatsealModel = GObject.registerClass({
             const entry = {};
             const isText = typeof pspec.get_default_value() === 'string';
             const appVersion = pspec.get_nick();
+            const [group] = property.split('-');
 
             entry['property'] = property;
             entry['description'] = pspec.get_blurb();
@@ -494,6 +503,8 @@ var FlatsealModel = GObject.registerClass({
             entry['type'] = isText ? 'text' : 'state';
             entry['permission'] = property.replace(/-/, '=');
             entry['supported'] = this._isSupported(appVersion);
+            entry['group'] = group;
+            entry['groupDescription'] = _groupDescriptions[group];
 
             list.push(entry);
         });

--- a/src/model.js
+++ b/src/model.js
@@ -110,6 +110,16 @@ var FlatsealModel = GObject.registerClass({
             '0.6.6',
             _('All devices (e.g. webcam)'),
             _propFlags, false),
+        'filesystems-host': GObject.ParamSpec.boolean(
+            'filesystems-host',
+            '0.4.0',
+            _('Access all system directories (unrestricted)'),
+            _propFlags, false),
+        'filesystems-home': GObject.ParamSpec.boolean(
+            'filesystems-home',
+            '0.4.0',
+            _('Access home directory (unrestricted)'),
+            _propFlags, false),
         'features-devel': GObject.ParamSpec.boolean(
             'features-devel',
             '0.6.10',
@@ -366,6 +376,7 @@ var FlatsealModel = GObject.registerClass({
                 value = permissions
                     .filter(p => p.startsWith(`${key}=`))
                     .map(p => p.split('=')[1])
+                    .filter(p => ['home', 'host'].indexOf(p) === -1)
                     .join(';');
             } else {
                 value = permissions.indexOf(permission) !== -1;

--- a/src/window.js
+++ b/src/window.js
@@ -20,6 +20,7 @@ const {GObject, Gtk} = imports.gi;
 const {Leaflet, TitleBar, SwipeGroup, Column} = imports.gi.Handy;
 
 const {FlatsealApplicationRow} = imports.applicationRow;
+const {FlatsealGroupRow} = imports.groupRow;
 const {FlatsealModel} = imports.model;
 const {FlatsealPermissionEntryRow} = imports.permissionEntryRow;
 const {FlatsealPermissionSwitchRow} = imports.permissionSwitchRow;
@@ -82,6 +83,8 @@ var FlatsealWindow = GObject.registerClass({
             this._applicationsListBox.add(row);
         });
 
+        var lastGroup = '';
+
         permissions.forEach(p => {
             var row;
 
@@ -89,6 +92,15 @@ var FlatsealWindow = GObject.registerClass({
                 row = new FlatsealPermissionEntryRow(p.description, p.permission, p.value);
             else
                 row = new FlatsealPermissionSwitchRow(p.description, p.permission, p.value);
+
+            const context = row.get_style_context();
+            context.add_class(p.group);
+
+            if (p.group !== lastGroup) {
+                const groupRow = new FlatsealGroupRow(p.group, p.groupDescription);
+                this._permissionsBox.add(groupRow);
+                lastGroup = p.group;
+            }
 
             row.sensitive = p.supported;
             this._permissionsBox.add(row);

--- a/tests/src/testModel.js
+++ b/tests/src/testModel.js
@@ -5,7 +5,7 @@ setup();
 
 const {FlatsealModel, DELAY, GROUP} = imports.model;
 
-const _totalPermissions = 20;
+const _totalPermissions = 22;
 
 const _basicAppId = 'com.test.Basic';
 const _oldAppId = 'com.test.Old';
@@ -95,7 +95,9 @@ describe('Model', function() {
         expect(model.features_devel).toBe(true);
         expect(model.features_multiarch).toBe(true);
         expect(model.features_canbus).toBe(true);
-        expect(model.filesystems_custom).toEqual('host;home;~/test');
+        expect(model.filesystems_host).toBe(true);
+        expect(model.filesystems_home).toBe(true);
+        expect(model.filesystems_custom).toEqual('~/test');
     });
 
     it('loads overrides', function() {
@@ -121,6 +123,8 @@ describe('Model', function() {
         expect(model.features_devel).toBe(false);
         expect(model.features_multiarch).toBe(false);
         expect(model.features_canbus).toBe(false);
+        expect(model.filesystems_host).toBe(false);
+        expect(model.filesystems_home).toBe(false);
         expect(model.filesystems_custom).toEqual('');
     });
 
@@ -133,6 +137,7 @@ describe('Model', function() {
         model.set_property('devices_dri', false);
         model.set_property('shared-network', false);
         model.set_property('features-bluetooth', false);
+        model.set_property('filesystems-host', false);
         model.set_property('filesystems-custom', '~/tset');
 
         GLib.timeout_add(GLib.PRIORITY_HIGH, DELAY + 1, () => {
@@ -163,6 +168,8 @@ describe('Model', function() {
         expect(model.features_bluetooth).toBe(false);
         expect(model.features_devel).toBe(true);
         expect(model.features_multiarch).toBe(true);
+        expect(model.filesystems_host).toBe(false);
+        expect(model.filesystems_home).toBe(true);
         expect(model.filesystems_custom).toEqual('~/tset');
     });
 


### PR DESCRIPTION
Remove visual clutter by grouping permissions. Use the same groups defined by Flatpak.

Closes #42