### PR TITLE
widgets: Fix missing icons

### DIFF
--- a/src/widgets/appInfoViewer.js
+++ b/src/widgets/appInfoViewer.js
@@ -59,13 +59,15 @@ var FlatsealAppInfoViewer = GObject.registerClass({
     }
 
     _setup() {
-        this._icon.set_from_icon_name(this._appId, Gtk.IconSize.INVALID);
-
         const appdata = this._applications.getAppDataForAppId(this._appId);
+        const desktop = this._applications.getDesktopForAppData(appdata);
+
         this._name.set_label(appdata.name);
         this._author.set_label(appdata.author);
         this._version.set_label(appdata.version);
         this._released.set_label(this._get_formatted_date(appdata.date));
+
+        this._icon.set_from_icon_name(desktop.icon, Gtk.IconSize.INVALID);
 
         const metadata = this._applications.getMetadataForAppId(this._appId);
         this._runtime.set_label(metadata.runtime);

--- a/src/widgets/applicationRow.js
+++ b/src/widgets/applicationRow.js
@@ -24,9 +24,9 @@ var FlatsealApplicationRow = GObject.registerClass({
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/applicationRow.ui',
     InternalChildren: ['icon', 'name', 'appId'],
 }, class FlatsealApplicationRow extends Gtk.ListBoxRow {
-    _init(appId, appName) {
+    _init(appId, appName, appIconName) {
         super._init();
-        this._icon.set_from_icon_name(appId, Gtk.IconSize.INVALID);
+        this._icon.set_from_icon_name(appIconName, Gtk.IconSize.INVALID);
         this._name.set_text(appName);
         this._appId.set_text(appId);
     }

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -107,7 +107,7 @@ var FlatsealWindow = GObject.registerClass({
 
         applications.forEach(app => {
             iconTheme.append_search_path(app.appThemePath);
-            const row = new FlatsealApplicationRow(app.appId, app.appName);
+            const row = new FlatsealApplicationRow(app.appId, app.appName, app.appIconName);
             this._applicationsListBox.add(row);
         });
 


### PR DESCRIPTION
This fixes most cases,  but in some cases icon  will only be available through urls (remote), and thats requires to grant Flatseal network permission, which I prefer not to do it.

Closes #107