### PR TITLE
widgets: Fix crash when multiple versions of libhandy are installed

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ pkg.initFormat();
 pkg.require({
     Gio: '2.0',
     Gtk: '3.0',
+    Handy: '0.0',
 });
 
 const {FlatsealApplication} = imports.application;


### PR DESCRIPTION
Prevents a crash when libhandy1 (0.80.0 and above) is installed along with libhandy 0.0 (0.0.13 and below).