### PR TITLE
applications: support custom flatpak user dir

### DIFF
--- a/com.github.tchx84.Flatseal.json
+++ b/com.github.tchx84.Flatseal.json
@@ -11,8 +11,8 @@
         "--socket=wayland",
         "--device=dri",
         "--filesystem=/var/lib/flatpak/app:ro",
-        "--filesystem=~/.local/share/flatpak/app:ro",
-        "--filesystem=~/.local/share/flatpak/overrides:create",
+        "--filesystem=xdg-data/flatpak/app:ro",
+        "--filesystem=xdg-data/flatpak/overrides:create",
         "--talk-name=org.gnome.Software"
     ],
     "cleanup": [

--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -29,8 +29,20 @@ var FlatpakApplicationsModel = GObject.registerClass({
         this._systemPath = GLib.build_filenamev([
             GLib.DIR_SEPARATOR_S, 'var', 'lib', 'flatpak',
         ]);
+        var userDataDir = GLib.get_user_data_dir();
+        if (GLib.getenv("FLATPAK_ID")) {
+            /* Inside flatpak, Glib.get_user_data_dir() would return
+             * the application's data directory. The host data directory
+             * is instead stored in HOST_XDG_DATA_HOME environment variable. */
+            userDataDir = GLib.getenv("HOST_XDG_DATA_HOME")
+            if (!userDataDir) {
+                userDataDir = GLib.build_filenamev([
+                    GLib.get_home_dir(), '.local', 'share',
+                ]);
+            }
+        }
         this._userPath = GLib.build_filenamev([
-            GLib.get_home_dir(), '.local', 'share', 'flatpak',
+            userDataDir, 'flatpak',
         ]);
         this._configPath = GLib.build_filenamev([
             GLib.DIR_SEPARATOR_S, 'run', 'host', 'etc', 'flatpak', 'installations.d',


### PR DESCRIPTION
Flatpak user installation directory can be moved with the `XDG_DATA_HOME`
variable (exported to flatpak as `HOST_XDG_DATA_HOME`). Check if this is
the case and set the user path accordingly.