### PR TITLE
window: Fix bottom action bar activation

### DIFF
--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -39,7 +39,7 @@ const _bindFlags = GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYN
 const _bindReadFlags = GObject.BindingFlags.SYNC_CREATE;
 
 const menuResource = '/com/github/tchx84/Flatseal/widgets/menu.ui';
-const ACTION_BAR_THRESHOLD = 360;
+const ACTION_BAR_THRESHOLD = 540;
 
 
 var FlatsealWindow = GObject.registerClass({


### PR DESCRIPTION
This workaround for the  geddan effect issue relies
on the header bar ability to shrink below a certain
threshold but, if this condition cannot be met then
the action bar simply won't activate.

Give it more room, by increasing the threshold.