### PR TITLE
portals: Forget past decisions on reset

### DIFF
--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -150,7 +150,7 @@ var FlatpakPermissionsModel = GObject.registerClass({
 
     _checkIfChanged() {
         const overrideExists = GLib.access(this._getOverridesPath(), 0) === 0;
-        const portalsChanged = MODELS.portals.changed(this);
+        const portalsChanged = MODELS.portals.changed();
         const changed = overrideExists || portalsChanged;
         const unsupported = !MODELS.unsupported.isEmpty();
         this.emit('changed', changed, unsupported);
@@ -255,7 +255,7 @@ var FlatpakPermissionsModel = GObject.registerClass({
     backup() {
         this._backup = new GLib.KeyFile();
         Object.values(MODELS).forEach(model => model.saveToKeyFile(this._backup));
-        MODELS.portals.backup(this);
+        MODELS.portals.backup();
     }
 
     reset() {

--- a/src/models/portals.js
+++ b/src/models/portals.js
@@ -98,8 +98,7 @@ var FlatpakPortalsModel = GObject.registerClass({
                 busName,
                 '/org/freedesktop/impl/portal/PermissionStore');
         } catch (err) {
-
-            /* pass */
+            logError(err);
         }
     }
 

--- a/tests/service.js
+++ b/tests/service.js
@@ -42,6 +42,11 @@ const PermissionsIface = `
             <arg type="s" name="app" direction="in"/>
             <arg type="as" name="permissions" direction="in"/>
         </method>
+        <method name="DeletePermission">
+            <arg name='table' type='s' direction='in'/>
+            <arg name='id' type='s' direction='in'/>
+            <arg name='app' type='s' direction='in'/>
+        </method>
         <property name="version" type="u" access="read"/>
     </interface>
 </node>
@@ -116,6 +121,13 @@ class MockPermissionsStore {
 
             const value = new GLib.Variant('(as)', [ids]);
             invocation.return_value(value);
+        } else if (method === 'DeletePermission') {
+            const [table, id, appId] = params.deep_unpack();
+
+            if (table in this._store && id in this._store[table] && appId in this._store[table][id])
+                delete this._store[table][id][appId];
+
+            invocation.return_value(null);
         }
     }
 

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -794,12 +794,12 @@ describe('Model', function() {
 
         permissions.reset();
 
-        expect(getValueFromService('background', 'background', 'no', _basicAppId)).toBe(true);
-        expect(getValueFromService('notifications', 'notification', 'no', _basicAppId)).toBe(true);
-        expect(getValueFromService('devices', 'microphone', 'no', _basicAppId)).toBe(true);
-        expect(getValueFromService('devices', 'speakers', 'no', _basicAppId)).toBe(true);
-        expect(getValueFromService('devices', 'camera', 'no', _basicAppId)).toBe(true);
-        expect(getValueFromService('location', 'location', 'NONE', _basicAppId)).toBe(true);
+        expect(getValueFromService('background', 'background', null, _basicAppId)).toBe(true);
+        expect(getValueFromService('notifications', 'notification', null, _basicAppId)).toBe(true);
+        expect(getValueFromService('devices', 'microphone', null, _basicAppId)).toBe(true);
+        expect(getValueFromService('devices', 'speakers', null, _basicAppId)).toBe(true);
+        expect(getValueFromService('devices', 'camera', null, _basicAppId)).toBe(true);
+        expect(getValueFromService('location', 'location', null, _basicAppId)).toBe(true);
     });
 
 
@@ -831,12 +831,12 @@ describe('Model', function() {
 
             permissions.reset();
 
-            expect(getValueFromService('background', 'background', 'no', _overridenAppId)).toBe(true);
-            expect(getValueFromService('notifications', 'notification', 'no', _overridenAppId)).toBe(true);
-            expect(getValueFromService('devices', 'microphone', 'no', _overridenAppId)).toBe(true);
-            expect(getValueFromService('devices', 'speakers', 'no', _overridenAppId)).toBe(true);
-            expect(getValueFromService('devices', 'camera', 'no', _overridenAppId)).toBe(true);
-            expect(getValueFromService('location', 'location', 'NONE', _overridenAppId)).toBe(true);
+            expect(getValueFromService('background', 'background', null, _overridenAppId)).toBe(true);
+            expect(getValueFromService('notifications', 'notification', null, _overridenAppId)).toBe(true);
+            expect(getValueFromService('devices', 'microphone', null, _overridenAppId)).toBe(true);
+            expect(getValueFromService('devices', 'speakers', null, _overridenAppId)).toBe(true);
+            expect(getValueFromService('devices', 'camera', null, _overridenAppId)).toBe(true);
+            expect(getValueFromService('location', 'location', null, _overridenAppId)).toBe(true);
 
             permissions.undo();
 


### PR DESCRIPTION
Flatseal couldn't "forget" current portals permissions due to
https://github.com/flatpak/xdg-desktop-portal/issues/573,  so
workaround the issue instead.