### PR TITLE
appInfoViewer: Fix permissions-view keyboard navigation

### DIFF
--- a/src/widgets/appInfoViewer.ui
+++ b/src/widgets/appInfoViewer.ui
@@ -4,7 +4,7 @@
   <requires lib="gtk+" version="3.22"/>
   <template class="FlatsealAppInfoViewer" parent="GtkBox">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can_focus">True</property>
     <property name="halign">start</property>
     <child>
       <object class="GtkBox">


### PR DESCRIPTION
Set AppInfoViewer can-focus to True, to allow navigation
all the way up with the keyboard, plus, this should help
with accessibility tools to scan the details widget.