### PR TITLE
applicationRow: Use HdyActionRow

### DIFF
--- a/src/application.css
+++ b/src/application.css
@@ -6,21 +6,6 @@
     margin: 10px;
 }
 
-.applications .icon {
-   padding-left: 5px;
-}
-
-.applications .name,
-.applications .app-id {
-   padding-left: 10px;
-   padding-right: 10px;
-}
-
-.applications .app-id {
-    font-style: italic;
-    font-size: small;
-}
-
 .applications .frame {
     border-width: 0px;
 }

--- a/src/widgets/applicationRow.js
+++ b/src/widgets/applicationRow.js
@@ -18,26 +18,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const {GObject, Gtk} = imports.gi;
+const {GObject, Gtk, Handy} = imports.gi;
 
 
 var FlatsealApplicationRow = GObject.registerClass({
     GTypeName: 'FlatsealApplicationRow',
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/applicationRow.ui',
-    InternalChildren: ['icon', 'name', 'appId'],
-}, class FlatsealApplicationRow extends Gtk.ListBoxRow {
+    InternalChildren: ['icon'],
+}, class FlatsealApplicationRow extends Handy.ActionRow {
     _init(appId, appName, appIconName) {
         super._init();
         this._icon.set_from_icon_name(appIconName, Gtk.IconSize.INVALID);
-        this._name.set_text(appName);
-        this._appId.set_text(appId);
+        this.set_title(appName);
+        this.set_subtitle(appId);
     }
 
     get appId() {
-        return this._appId.get_text();
+        return this.get_subtitle();
     }
 
     get appName() {
-        return this._name.get_text();
+        return this.get_title();
     }
 });

--- a/src/widgets/applicationRow.ui
+++ b/src/widgets/applicationRow.ui
@@ -11,9 +11,8 @@
         <property name="can-focus">False</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="pixel-size">40</property>
+        <property name="pixel-size">48</property>
         <property name="icon-name">com.github.tchx84.Flatseal</property>
-        <property name="icon_size">0</property>
         <style>
           <class name="icon"/>
           <class name="lowres-icon"/>

--- a/src/widgets/applicationRow.ui
+++ b/src/widgets/applicationRow.ui
@@ -2,96 +2,22 @@
 <!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <template class="FlatsealApplicationRow" parent="GtkListBoxRow">
+  <template class="FlatsealApplicationRow" parent="HdyActionRow">
     <property name="visible">True</property>
     <property name="can-focus">True</property>
-    <child>
-      <object class="GtkBox">
-        <property name="height-request">50</property>
+    <child type="prefix">
+      <object class="GtkImage" id="icon">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="valign">center</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkImage" id="icon">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="pixel-size">40</property>
-                <property name="icon-name">com.github.tchx84.Flatseal</property>
-                <property name="icon_size">0</property>
-                <style>
-                  <class name="icon"/>
-                  <class name="lowres-icon"/>
-                </style>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="valign">center</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkLabel" id="name">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="ellipsize">end</property>
-                <property name="single-line-mode">True</property>
-                <style>
-                  <class name="name"/>
-                </style>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="appId">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="ellipsize">end</property>
-                <property name="single-line-mode">True</property>
-                <style>
-                  <class name="app-id"/>
-                </style>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="pixel-size">40</property>
+        <property name="icon-name">com.github.tchx84.Flatseal</property>
+        <property name="icon_size">0</property>
+        <style>
+          <class name="icon"/>
+          <class name="lowres-icon"/>
+        </style>
       </object>
     </child>
     <style>

--- a/src/widgets/window.ui
+++ b/src/widgets/window.ui
@@ -20,6 +20,7 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
+            <property name="hexpand">False</property>
             <child>
               <object class="HdyHeaderBar" id="applicationsHeaderBar">
                 <property name="width-request">360</property>


### PR DESCRIPTION
HdyActionRow gives us title and subtitle styling for
list rows that's consistent with other GNOME apps.

The previous styling used italics for subtitles,
which is general discouraged. See: https://developer.gnome.org/hig/guidelines/typography.html