### PR TITLE
application: Use the standard shortcut to quit

### DIFF
--- a/src/application.css
+++ b/src/application.css
@@ -233,7 +233,7 @@ window .menu.background label {
 /* keybindings */
 
 @binding-set WindowBindings {
-  bind "<Alt>q" { "close" () };
+  bind "<Primary>q" { "close" () };
 }
 
 window {

--- a/src/application.js
+++ b/src/application.js
@@ -75,7 +75,7 @@ var FlatsealApplication = GObject.registerClass({
         this.add_action(quit_action);
 
         this.set_accels_for_action('app.documentation', ['F1']);
-        this.set_accels_for_action('app.quit', ['<alt>q']);
+        this.set_accels_for_action('app.quit', ['<Primary>q']);
     }
 
     _setupStylesheet() {


### PR DESCRIPTION
The standard shortcut for quitting applications is
Ctrl+Q, not Alt+Q.