### PR TITLE
Add --allow=per-app-dev-shm

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -71,6 +71,7 @@ Development syscalls | Toggle | Allow the application to access to certain sysca
 Programs from other architectures | Toggle | Allow the application to execute programs for an [ABI](https://en.wikipedia.org/wiki/Application_binary_interface) other than the one supported natively by the system. | `--allow=multiarch` and `--disallow=multiarch`
 Bluetooth | Toggle | Allow the application to use Bluetooth. | `--allow=bluetooth` and `--disallow=bluetooth`
 Controller Area Network bus | Toggle | Allow the application to use canbus sockets. You must also have [network access](#share) for this to work. | `--allow=canbus` and `--disallow=canbus`
+Per app /dev/shm | Toggle | Allow the application to share its `/dev/shm` by creating a per app folder in the hosts `/dev/shm` like this `/dev/shm/flatpak-$FLATPAK_APP_ID-XXXXXX`. This feature was added specifically to enable `com.valvesoftware.Steam` to share its `/dev/shm` with its sub-sandboxed games. | `--allow=per-app-dev-shm` and `--disallow=per-app-dev-shm`.
 
 ### Filesystem
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -71,7 +71,7 @@ Development syscalls | Toggle | Allow the application to access to certain sysca
 Programs from other architectures | Toggle | Allow the application to execute programs for an [ABI](https://en.wikipedia.org/wiki/Application_binary_interface) other than the one supported natively by the system. | `--allow=multiarch` and `--disallow=multiarch`
 Bluetooth | Toggle | Allow the application to use Bluetooth. | `--allow=bluetooth` and `--disallow=bluetooth`
 Controller Area Network bus | Toggle | Allow the application to use canbus sockets. You must also have [network access](#share) for this to work. | `--allow=canbus` and `--disallow=canbus`
-Per app /dev/shm | Toggle | Allow the application to share its /dev/shm between instances of the same $FLATPAK_APP_ID. Introduced specifically for the Steam flatpak, to enable sharing its /dev/shm with sub-sandboxed games. | `--allow=per-app-dev-shm` and `--disallow=per-app-dev-shm`.
+Application Shared Memory | Toggle | Allow the application to share its /dev/shm between instances of the same $FLATPAK_APP_ID. Introduced specifically for the Steam flatpak, to share its /dev/shm with sub-sandboxed games. | `--allow=per-app-dev-shm` and `--disallow=per-app-dev-shm`.
 
 ### Filesystem
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -71,7 +71,7 @@ Development syscalls | Toggle | Allow the application to access to certain sysca
 Programs from other architectures | Toggle | Allow the application to execute programs for an [ABI](https://en.wikipedia.org/wiki/Application_binary_interface) other than the one supported natively by the system. | `--allow=multiarch` and `--disallow=multiarch`
 Bluetooth | Toggle | Allow the application to use Bluetooth. | `--allow=bluetooth` and `--disallow=bluetooth`
 Controller Area Network bus | Toggle | Allow the application to use canbus sockets. You must also have [network access](#share) for this to work. | `--allow=canbus` and `--disallow=canbus`
-Per app /dev/shm | Toggle | Allow the application to share its `/dev/shm` by creating a per app folder in the hosts `/dev/shm` like this `/dev/shm/flatpak-$FLATPAK_APP_ID-XXXXXX`. This feature was added specifically to enable `com.valvesoftware.Steam` to share its `/dev/shm` with its sub-sandboxed games. | `--allow=per-app-dev-shm` and `--disallow=per-app-dev-shm`.
+Per app /dev/shm | Toggle | Allow the application to share its /dev/shm between instances of the same $FLATPAK_APP_ID. Introduced specifically for the Steam flatpak, to enable sharing its /dev/shm with sub-sandboxed games. | `--allow=per-app-dev-shm` and `--disallow=per-app-dev-shm`.
 
 ### Filesystem
 

--- a/help/C/index.html
+++ b/help/C/index.html
@@ -282,7 +282,7 @@
 <td>Application Shared Memory</td>
 <td>Toggle</td> 
 <td>Allow the application to share its /dev/shm between instances of the same $FLATPAK_APP_ID. Introduced specifically for the Steam flatpak, to share its /dev/shm with sub-sandboxed games.</td>
-<td><code>--allow=per-app-dev-shm</code>and <code>--disallow=per-app-dev-shm</code></td>
+<td><code>--allow=per-app-dev-shm</code> and <code>--disallow=per-app-dev-shm</code></td>
 </tr>
 </tbody>
 </table>

--- a/help/C/index.html
+++ b/help/C/index.html
@@ -279,9 +279,9 @@
 <td><code>--allow=canbus</code> and <code>--disallow=canbus</code></td>
 </tr>
 <tr class="odd">
-<td>Per app /dev/shm</td>
+<td>Application Shared Memory</td>
 <td>Toggle</td> 
-<td>Allow the application to share its /dev/shm between instances of the same $FLATPAK_APP_ID. Introduced specifically for the Steam flatpak, to enable sharing its /dev/shm with sub-sandboxed games.</td>
+<td>Allow the application to share its /dev/shm between instances of the same $FLATPAK_APP_ID. Introduced specifically for the Steam flatpak, to share its /dev/shm with sub-sandboxed games.</td>
 <td><code>--allow=per-app-dev-shm</code>and <code>--disallow=per-app-dev-shm</code></td>
 </tr>
 </tbody>

--- a/help/C/index.html
+++ b/help/C/index.html
@@ -281,7 +281,7 @@
 <tr class="odd">
 <td>Per app /dev/shm</td>
 <td>Toggle</td> 
-<td>Allow the application to share its /dev/shm by creating a per app folder in the hosts /dev/shm like this <code>/dev/shm/flatpak-$FLATPAK_APP_ID-XXXXXX</code>. This feature was added specifically to enable com.valvesoftware.Steam to share its /dev/shm with its sub-sandboxed games.</td>
+<td>Allow the application to share its /dev/shm between instances of the same $FLATPAK_APP_ID. Introduced specifically for the Steam flatpak, to enable sharing its /dev/shm with sub-sandboxed games.</td>
 <td><code>--allow=per-app-dev-shm</code>and <code>--disallow=per-app-dev-shm</code></td>
 </tr>
 </tbody>

--- a/help/C/index.html
+++ b/help/C/index.html
@@ -278,6 +278,12 @@
 <td>Allow the application to use canbus sockets. You must also have <a href="#share">network access</a> for this to work.</td>
 <td><code>--allow=canbus</code> and <code>--disallow=canbus</code></td>
 </tr>
+<tr class="odd">
+<td>Per app /dev/shm</td>
+<td>Toggle</td> 
+<td>Allow the application to share its /dev/shm by creating a per app folder in the hosts /dev/shm like this <code>/dev/shm/flatpak-$FLATPAK_APP_ID-XXXXXX</code>. This feature was added specifically to enable com.valvesoftware.Steam to share its /dev/shm with its sub-sandboxed games.</td>
+<td><code>--allow=per-app-dev-shm</code>and <code>--disallow=per-app-dev-shm</code></td>
+</tr>
 </tbody>
 </table>
 <h3 id="filesystem">Filesystem</h3>

--- a/src/models/features.js
+++ b/src/models/features.js
@@ -62,7 +62,7 @@ var FlatpakFeaturesModel = GObject.registerClass({
             },
             'features-per-app-dev-shm': {
                 supported: this._info.supports('1.11.1'),
-                description: _('Per app /dev/shm'),
+                description: _('Application Shared Memory'),
                 option: 'per-app-dev-shm',
                 value: this.constructor.getDefault(),
                 example: 'allow=per-app-dev-shm',

--- a/src/models/features.js
+++ b/src/models/features.js
@@ -60,6 +60,13 @@ var FlatpakFeaturesModel = GObject.registerClass({
                 value: this.constructor.getDefault(),
                 example: 'allow=canbus',
             },
+            'features-per-app-dev-shm': {
+                supported: this._info.supports('1.11.1'),
+                description: _('Per app /dev/shm'),
+                option: 'per-app-dev-shm',
+                value: this.constructor.getDefault(),
+                example: 'allow=per-app-dev-shm',
+            },
         };
     }
 

--- a/tests/content/system/flatpak/app/com.test.Basic/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Basic/current/active/metadata
@@ -2,7 +2,7 @@
 shared=network;ipc;
 sockets=x11;fallback-x11;wayland;pulseaudio;system-bus;session-bus;ssh-auth;pcsc;cups;
 devices=dri;kvm;shm;all;
-features=bluetooth;devel;multiarch;canbus;
+features=bluetooth;devel;multiarch;canbus;per-app-dev-shm;
 filesystems=host;host-os;host-etc;home;~/test;
 persistent=.test;
 

--- a/tests/content/user/flatpak/overrides/com.test.Basic
+++ b/tests/content/user/flatpak/overrides/com.test.Basic
@@ -2,7 +2,7 @@
 shared=!network;!ipc;
 sockets=!x11;!fallback-x11;!wayland;!pulseaudio;!system-bus;!session-bus;!ssh-auth;!pcsc;!cups;
 devices=!dri;!kvm;!shm;!all;
-features=!bluetooth;!devel;!multiarch;!canbus;
+features=!bluetooth;!devel;!multiarch;!canbus;!per-app-dev-shm;
 filesystems=!host;!host-os;!host-etc;!home;!~/test;
 persistent=tset.
 

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -32,7 +32,7 @@ const {
 
 setup();
 
-const _totalPermissions = 36;
+const _totalPermissions = 37;
 
 const _basicAppId = 'com.test.Basic';
 const _oldAppId = 'com.test.Old';

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -33,7 +33,6 @@ const {
 setup();
 
 const _totalPermissions = 37;
-const _stablePermissions = _totalPermissions - 7;
 
 const _basicAppId = 'com.test.Basic';
 const _oldAppId = 'com.test.Old';
@@ -557,7 +556,7 @@ describe('Model', function() {
         permissions.appId = _basicAppId;
         const total = permissions.getAll().filter(p => p.supported).length;
 
-        expect(total).toEqual(_stablePermissions);
+        expect(total).toEqual(_totalPermissions - 7);
     });
 
     it('handles missing .flatpak-info', function() {
@@ -933,7 +932,7 @@ describe('Model', function() {
 
         const total = permissions.getAll().filter(p => p.supported).length;
 
-        expect(total).toEqual(_stablePermissions);
+        expect(total).toEqual(_totalPermissions - 6);
 
         expect(permissions.portals_background).toBe(portalState.UNSUPPORTED);
         expect(permissions.portals_notification).toBe(portalState.UNSUPPORTED);

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -157,6 +157,7 @@ describe('Model', function() {
         expect(permissions.features_devel).toBe(true);
         expect(permissions.features_multiarch).toBe(true);
         expect(permissions.features_canbus).toBe(true);
+        expect(permissions.features_per_app_dev_shm).toBe(true);
         expect(permissions.filesystems_host).toBe(true);
         expect(permissions.filesystems_host_os).toBe(true);
         expect(permissions.filesystems_host_etc).toBe(true);
@@ -193,6 +194,7 @@ describe('Model', function() {
         expect(permissions.features_devel).toBe(false);
         expect(permissions.features_multiarch).toBe(false);
         expect(permissions.features_canbus).toBe(false);
+        expect(permissions.features_per_app_dev_shm).toBe(false);
         expect(permissions.filesystems_host).toBe(false);
         expect(permissions.filesystems_host_os).toBe(false);
         expect(permissions.filesystems_host_etc).toBe(false);

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -33,6 +33,7 @@ const {
 setup();
 
 const _totalPermissions = 37;
+const _stablePermissions = _totalPermissions - 7;
 
 const _basicAppId = 'com.test.Basic';
 const _oldAppId = 'com.test.Old';
@@ -556,7 +557,7 @@ describe('Model', function() {
         permissions.appId = _basicAppId;
         const total = permissions.getAll().filter(p => p.supported).length;
 
-        expect(total).toEqual(_totalPermissions - 6);
+        expect(total).toEqual(_stablePermissions);
     });
 
     it('handles missing .flatpak-info', function() {
@@ -932,7 +933,7 @@ describe('Model', function() {
 
         const total = permissions.getAll().filter(p => p.supported).length;
 
-        expect(total).toEqual(_totalPermissions - 6);
+        expect(total).toEqual(_stablePermissions);
 
         expect(permissions.portals_background).toBe(portalState.UNSUPPORTED);
         expect(permissions.portals_notification).toBe(portalState.UNSUPPORTED);


### PR DESCRIPTION
## Why?

From Flatpak 1.11.1 [release notes](https://github.com/flatpak/flatpak/releases/tag/1.11.1):
>- Instances of the same app-ID can optionally share their /dev/shm directory
(enabled by a new --allow flag, --allow=per-app-dev-shm)

## TODO 
- [x] Build and run Flatseal. 
    Here is what I did:
    ```sh
    git clone https://github.com/tchx84/Flatseal.git
    cd Flatseal/
    sudo apt install flatpak-builder
    flatpak install org.gnome.Sdk/x86_64/41
    flatpak install org.gnome.Platform/x86_64/41
    flatpak-builder --force-clean --repo=repo/ build/ com.github.tchx84.Flatseal.json
    flatpak build-bundle repo/ Flatseal.flatpak com.github.tchx84.Flatseal
    flatpak install --user Flatseal.flatpak
    flatpak run --branch=master com.github.tchx84.Flatseal
    ```
- [x] Test 

| State | In GUI | In overrides file |
|-----------------|---------------|-----------|
| Toggled on |  ![image](https://user-images.githubusercontent.com/3092618/137978956-0a964b46-812f-4671-8f60-113bcac89f65.png) | ![image](https://user-images.githubusercontent.com/3092618/137979365-a2de7112-3f8b-49f8-9c9a-209a39b434ef.png) |
|  Toggled off | ![image](https://user-images.githubusercontent.com/3092618/137979275-e3ba466d-750d-488e-aefc-5a5e23c722a7.png) | ![image](https://user-images.githubusercontent.com/3092618/137979436-5a7b78c1-ee87-400d-af65-fb451b2e46ea.png) |



