### PR TITLE
pathViewer: Fix possible misuse of GJS garbage collector 

### DIFF
--- a/src/widgets/pathsViewer.js
+++ b/src/widgets/pathsViewer.js
@@ -45,12 +45,14 @@ var FlatsealPathsViewer = GObject.registerClass({
     }
 
     _remove(row) {
+        this._box.remove(row);
         row.destroy();
         this._changed();
     }
 
     _update(text) {
         this._box.get_children().forEach(row => {
+            this._box.remove(row);
             row.destroy();
         });
 


### PR DESCRIPTION
From logs:

Attempting to call back into JSAPI during the sweeping phase of GC.
This is most likely caused by not destroying a Clutter actor or Gtk+
widget with ::destroy signals connected, but can also be caused by
using the destroy(), dispose(), or remove() vfuncs. Because it would
crash the application, it has been blocked and the JS callback not
invoked.

This is quite hard to reproduce, so I won't be really sure
this makes any  difference until I can test it more.