### PR TITLE
test: Add 2 new tests, trying to demonstrate that overriding negated permissions does not always display correctly

### DIFF
--- a/tests/content/system/flatpak/app/com.test.BasicNegative/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.BasicNegative/current/active/metadata
@@ -1,0 +1,18 @@
+[Context]
+shared=!network;!ipc;
+sockets=!x11;!fallback-x11;!wayland;!pulseaudio;!system-bus;!session-bus;!ssh-auth;!pcsc;!cups;
+devices=!dri;!kvm;!shm;!all;
+features=!bluetooth;!devel;!multiarch;!canbus;!per-app-dev-shm;
+filesystems=!host;!host-os;!host-etc;!home;!~/test;
+persistent=tset.
+
+[Environment]
+TEST=no
+
+[Session Bus Policy]
+org.test.Service-1=none
+org.test.Service-2=none
+
+[System Bus Policy]
+org.test.Service-3=none
+org.test.Service-4=none

--- a/tests/content/user/flatpak/overrides/com.test.BasicNegative
+++ b/tests/content/user/flatpak/overrides/com.test.BasicNegative
@@ -1,0 +1,18 @@
+[Context]
+shared=network;ipc;
+sockets=x11;fallback-x11;wayland;pulseaudio;system-bus;session-bus;ssh-auth;pcsc;cups;
+devices=dri;kvm;shm;all;
+features=bluetooth;devel;multiarch;canbus;per-app-dev-shm;
+filesystems=host;host-os;host-etc;home;~/test;
+persistent=.test;
+
+[Environment]
+TEST=yes
+
+[Session Bus Policy]
+org.test.Service-1=talk
+org.test.Service-2=own
+
+[System Bus Policy]
+org.test.Service-3=talk
+org.test.Service-4=own

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -35,6 +35,7 @@ setup();
 const _totalPermissions = 37;
 
 const _basicAppId = 'com.test.Basic';
+const _basicNegativeAppId = 'com.test.BasicNegative';
 const _oldAppId = 'com.test.Old';
 const _reduceAppId = 'com.test.Reduce';
 const _increaseAppId = 'com.test.Increase';
@@ -117,6 +118,7 @@ describe('Model', function() {
         const appIds = applications.getAll().map(a => a.appId);
 
         expect(appIds).toContain(_basicAppId);
+        expect(appIds).toContain(_basicNegativeAppId);
         expect(appIds).toContain(_oldAppId);
         expect(appIds).toContain(_reduceAppId);
         expect(appIds).toContain(_increaseAppId);
@@ -135,7 +137,7 @@ describe('Model', function() {
         expect(appIds).not.toContain(_baseAppId);
     });
 
-    it('loads permissions', function() {
+    it('loads positive permissions', function() {
         permissions.appId = _basicAppId;
 
         expect(permissions.shared_network).toBe(true);
@@ -171,7 +173,7 @@ describe('Model', function() {
         expect(permissions.variables).toEqual('TEST=yes');
     });
 
-    it('loads overrides', function() {
+    it('loads negative overrides', function() {
         GLib.setenv('FLATPAK_USER_DIR', _user, true);
         permissions.appId = _basicAppId;
 
@@ -205,6 +207,78 @@ describe('Model', function() {
         expect(permissions.system_own).toEqual('');
         expect(permissions.persistent).toEqual('.test;tset.');
         expect(permissions.variables).toEqual('TEST=no');
+    });
+
+    it('loads negative permissions', function() {
+        permissions.appId = _basicNegativeAppId;
+
+        expect(permissions.shared_network).toBe(false);
+        expect(permissions.shared_ipc).toBe(false);
+        expect(permissions.sockets_x11).toBe(false);
+        expect(permissions.sockets_fallback_x11).toBe(false);
+        expect(permissions.sockets_wayland).toBe(false);
+        expect(permissions.sockets_pulseaudio).toBe(false);
+        expect(permissions.sockets_system_bus).toBe(false);
+        expect(permissions.sockets_session_bus).toBe(false);
+        expect(permissions.sockets_ssh_auth).toBe(false);
+        expect(permissions.sockets_pcsc).toBe(false);
+        expect(permissions.sockets_cups).toBe(false);
+        expect(permissions.devices_dri).toBe(false);
+        expect(permissions.devices_kvm).toBe(false);
+        expect(permissions.devices_shm).toBe(false);
+        expect(permissions.devices_all).toBe(false);
+        expect(permissions.features_bluetooth).toBe(false);
+        expect(permissions.features_devel).toBe(false);
+        expect(permissions.features_multiarch).toBe(false);
+        expect(permissions.features_canbus).toBe(false);
+        expect(permissions.features_per_app_dev_shm).toBe(false);
+        expect(permissions.filesystems_host).toBe(false);
+        expect(permissions.filesystems_host_os).toBe(false);
+        expect(permissions.filesystems_host_etc).toBe(false);
+        expect(permissions.filesystems_home).toBe(false);
+        expect(permissions.session_talk).toEqual('');
+        expect(permissions.session_own).toEqual('');
+        expect(permissions.system_talk).toEqual('');
+        expect(permissions.system_own).toEqual('');
+        expect(permissions.persistent).toEqual('.test;tset.');
+        expect(permissions.variables).toEqual('TEST=no');
+    });
+
+    it('loads positive overrides', function() {
+        GLib.setenv('FLATPAK_USER_DIR', _user, true);
+        permissions.appId = _basicNegativeAppId;
+
+        expect(permissions.shared_network).toBe(true);
+        expect(permissions.shared_ipc).toBe(true);
+        expect(permissions.sockets_x11).toBe(true);
+        expect(permissions.sockets_fallback_x11).toBe(true);
+        expect(permissions.sockets_wayland).toBe(true);
+        expect(permissions.sockets_pulseaudio).toBe(true);
+        expect(permissions.sockets_system_bus).toBe(true);
+        expect(permissions.sockets_session_bus).toBe(true);
+        expect(permissions.sockets_ssh_auth).toBe(true);
+        expect(permissions.sockets_pcsc).toBe(true);
+        expect(permissions.sockets_cups).toBe(true);
+        expect(permissions.devices_dri).toBe(true);
+        expect(permissions.devices_kvm).toBe(true);
+        expect(permissions.devices_shm).toBe(true);
+        expect(permissions.devices_all).toBe(true);
+        expect(permissions.features_bluetooth).toBe(true);
+        expect(permissions.features_devel).toBe(true);
+        expect(permissions.features_multiarch).toBe(true);
+        expect(permissions.features_canbus).toBe(true);
+        expect(permissions.features_per_app_dev_shm).toBe(true);
+        expect(permissions.filesystems_host).toBe(true);
+        expect(permissions.filesystems_host_os).toBe(true);
+        expect(permissions.filesystems_host_etc).toBe(true);
+        expect(permissions.filesystems_home).toBe(true);
+        expect(permissions.filesystems_other).toEqual('~/test');
+        expect(permissions.session_talk).toEqual('org.test.Service-1');
+        expect(permissions.session_own).toEqual('org.test.Service-2');
+        expect(permissions.system_talk).toEqual('org.test.Service-3');
+        expect(permissions.system_own).toEqual('org.test.Service-4');
+        expect(permissions.persistent).toEqual('.test');
+        expect(permissions.variables).toEqual('TEST=yes');
     });
 
     it('creates overrides when properties changed', function(done) {

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -240,7 +240,7 @@ describe('Model', function() {
         expect(permissions.session_own).toEqual('');
         expect(permissions.system_talk).toEqual('');
         expect(permissions.system_own).toEqual('');
-        expect(permissions.persistent).toEqual('.test;tset.');
+        expect(permissions.persistent).toEqual('tset.');
         expect(permissions.variables).toEqual('TEST=no');
     });
 
@@ -277,7 +277,7 @@ describe('Model', function() {
         expect(permissions.session_own).toEqual('org.test.Service-2');
         expect(permissions.system_talk).toEqual('org.test.Service-3');
         expect(permissions.system_own).toEqual('org.test.Service-4');
-        expect(permissions.persistent).toEqual('.test');
+        expect(permissions.persistent).toEqual('tset.;.test');
         expect(permissions.variables).toEqual('TEST=yes');
     });
 


### PR DESCRIPTION
## Changelog
- Add test  'Load negative permissions'
- Add test 'Load positive overrides'
- Rename test 'Load permissions' -> 'Load positive permissions'
- Rename test 'Load overrides' -> 'Load negative overrides'

## Fix
If the new tests proves the hypothesis, I will create a new PR with the fix.
**Update** - Success! looks like the tests fails the way that was expected :partying_face: 

## Logs
For reference, here is the important part of the logs from the test-run:
```
 ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

4/4 Jasmine tests           FAIL           15.60s   exit status 1
――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――
Started

  Model
    ✓ loads applications (45.128 ms)
    ✓ ignores BaseApp bundles
    ✓ loads positive permissions
    ✓ loads negative overrides
    ✓ loads negative permissions
    1) loads positive overrides
    ✓ creates overrides when properties changed (539.174 ms)
    ✓ reloads previous overrides later on
    ✓ resets overrides (43.253 ms)
    ✓ creates overrides only when properties values changed (536.202 ms)
    ✓ loads old filesystems overrides
    ✓ reduces filesystems permission (535.211 ms)
    ✓ increases filesystems permission (535.046 ms)
    ✓ increases filesystems permission (default) (532.249 ms)
    ✓ handles negated filesystems permission (532.686 ms)
    ✓ handles removing negated filesystems permission (534.828 ms)
    ✓ handles adding negated filesystems override (manually) (532.96 ms)
    ✓ handles removing negated filesystems override (manually) (532.877 ms)
    ✓ ignores unsupported permissions (533.049 ms)
    ✓ signals changes with overrides (537.853 ms)
    ✓ signals changes with no overrides (43.446 ms)
    ✓ signals changes with unsupported overrides
    ✓ signals changes without unsupported overrides
    ✓ saves pending updates before selecting other application (542.468 ms)
    ✓ saves pending updates before shutting down (535.239 ms)
    ✓ disables all permissions with old flatpak version
    ✓ enables all permissions with new flatpak version
    ✓ disables permissions with stable flatpak version
    ✓ handles missing .flatpak-info
    ✓ loads extra applications
    ✓ preserves installation priorities
    ✓ add new environment variable (532.628 ms)
    ✓ override original environment variable (531.964 ms)
    ✓ remove original environment variable (531.028 ms)
    ✓ handles re-loading removed variables
    ✓ handles non-valid environment variable (540.545 ms)
    ✓ handles RUST debug export environment variables (547.581 ms)
    ✓ Add new well-known names (534.646 ms)
    ✓ Remove well-known names (539.588 ms)
    ✓ Modify well-known names (539.883 ms)
    ✓ signals reset when done explicitly (42.36 ms)
    ✓ restores overrides when undo (571.842 ms)
    ✓ handles portals permissions (545.706 ms)
    ✓ resets portals permissions (60.852 ms)
    ✓ restores portals permissions when undo (623.273 ms)
    ✓ does not write to the store unnecessarily
    ✓ handles portals with partial tables on permission store
    ✓ handles writing to missing pair on permission store (534.536 ms)
    ✓ handles portals without permission store

...

1) Model loads positive overrides

  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:251:44
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:252:40
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:253:41
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:254:50
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:255:45
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:256:48
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:257:48
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:258:49
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:259:46
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:260:42
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:261:42
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:262:41
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:263:41
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:264:41
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:265:41
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:266:48
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:267:44
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:268:48
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:269:45
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:270:54
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:271:46
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:272:49
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:273:50
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  Expected false to be true.
    @/github/workspace/tests/src/testModels.js:274:46
    run@resource:///org/gnome/gjs/modules/script/mainloop.js:36:22
    @/usr/local/libexec/jasmine-gjs/jasmine-runner:42:9


  85 passing (15.38 s)
  1 failing

――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

```