### PR TITLE
window: Limit application-activation to compact mode

### DIFF
--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -249,7 +249,8 @@ var FlatsealWindow = GObject.registerClass({
     }
 
     _activateApplication() {
-        this._showPermissions();
+        if (this._contentLeaflet.folded)
+            this._showPermissions();
     }
 
     _selectApplication() {


### PR DESCRIPTION
The reason for  the activation of  applications is to
handle the keyboard navigation in compact mode, which
is well defined now.

Navigation on non-compact mode is  less defined at the
moment, so is better to prevent activation to keep the
UI behavior consistent.