### PR TITLE
Update copyright

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -3,7 +3,7 @@
 
 /* application.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 
 /* main.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -1,6 +1,6 @@
 /* applications.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/devices.js
+++ b/src/models/devices.js
@@ -2,7 +2,7 @@
 
 /* devices.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/features.js
+++ b/src/models/features.js
@@ -2,7 +2,7 @@
 
 /* features.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/filesystems.js
+++ b/src/models/filesystems.js
@@ -2,7 +2,7 @@
 
 /* filesystems.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/filesystemsOther.js
+++ b/src/models/filesystemsOther.js
@@ -2,7 +2,7 @@
 
 /* filesystemsOther.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/info.js
+++ b/src/models/info.js
@@ -2,7 +2,7 @@
 
 /* info.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -2,7 +2,7 @@
 
 /* permissions.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/persistent.js
+++ b/src/models/persistent.js
@@ -2,7 +2,7 @@
 
 /* persistent.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/sessionBus.js
+++ b/src/models/sessionBus.js
@@ -2,7 +2,7 @@
 
 /* sessionBus.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/settings.js
+++ b/src/models/settings.js
@@ -2,7 +2,7 @@
 
 /* settings.js
  *
- * Copyright 2021 Martin Abente Lahaye
+ * Copyright 2021 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/shared.js
+++ b/src/models/shared.js
@@ -2,7 +2,7 @@
 
 /* shared.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/sockets.js
+++ b/src/models/sockets.js
@@ -2,7 +2,7 @@
 
 /* sockets.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/systemBus.js
+++ b/src/models/systemBus.js
@@ -2,7 +2,7 @@
 
 /* sessionBus.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/unsupported.js
+++ b/src/models/unsupported.js
@@ -3,7 +3,7 @@
 
 /* unsupported.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/models/variables.js
+++ b/src/models/variables.js
@@ -2,7 +2,7 @@
 
 /* variables.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/aboutDialog.js
+++ b/src/widgets/aboutDialog.js
@@ -2,7 +2,7 @@
 
 /* aboutDialog.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/aboutDialog.ui
+++ b/src/widgets/aboutDialog.ui
@@ -7,7 +7,7 @@
     <property name="type_hint">dialog</property>
     <property name="program_name">Flatseal</property>
     <property name="version">1.7.5</property>
-    <property name="copyright">© 2020-2021 Martin Abente Lahaye</property>
+    <property name="copyright">© 2020 The Flatseal Authors</property>
     <property name="comments" translatable="yes">Flatseal is a graphical utility to review and modify permissions from your Flatpak applications.</property>
     <property name="website">https://github.com/tchx84/flatseal</property>
     <property name="website_label">Flatseal</property>

--- a/src/widgets/appInfoViewer.js
+++ b/src/widgets/appInfoViewer.js
@@ -3,7 +3,7 @@
 
 /* appInfoViewer.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/applicationRow.js
+++ b/src/widgets/applicationRow.js
@@ -2,7 +2,7 @@
 
 /* applicationRow.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/busNameRow.js
+++ b/src/widgets/busNameRow.js
@@ -2,7 +2,7 @@
 
 /* busNameRow.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/detailsButton.js
+++ b/src/widgets/detailsButton.js
@@ -2,7 +2,7 @@
 
 /* detailsButton.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/docsViewer.js
+++ b/src/widgets/docsViewer.js
@@ -2,7 +2,7 @@
 
 /* docsViewer.js
  *
- * Copyright 2021 Martin Abente Lahaye
+ * Copyright 2021 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/pathRow.js
+++ b/src/widgets/pathRow.js
@@ -2,7 +2,7 @@
 
 /* pathRow.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/pathsViewer.js
+++ b/src/widgets/pathsViewer.js
@@ -2,7 +2,7 @@
 
 /* pathsViewer.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/permissionEntryRow.js
+++ b/src/widgets/permissionEntryRow.js
@@ -2,7 +2,7 @@
 
 /* permissionEntryRow.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/permissionPortalRow.js
+++ b/src/widgets/permissionPortalRow.js
@@ -2,7 +2,7 @@
 
 /* permissionPortalRow.js
  *
- * Copyright 2021 Martin Abente Lahaye
+ * Copyright 2021 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/permissionSwitchRow.js
+++ b/src/widgets/permissionSwitchRow.js
@@ -2,7 +2,7 @@
 
 /* permissionSwitchRow.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/relativePathRow.js
+++ b/src/widgets/relativePathRow.js
@@ -2,7 +2,7 @@
 
 /* relativePathRow.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/resetButton.js
+++ b/src/widgets/resetButton.js
@@ -2,7 +2,7 @@
 
 /* resetButton.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/shortcutsWindow.js
+++ b/src/widgets/shortcutsWindow.js
@@ -2,7 +2,7 @@
 
 /* shortcutsWindow.js
  *
- * Copyright 2021 Martin Abente Lahaye
+ * Copyright 2021 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/undoPopup.js
+++ b/src/widgets/undoPopup.js
@@ -2,7 +2,7 @@
 
 /* undoPopup.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/variableRow.js
+++ b/src/widgets/variableRow.js
@@ -2,7 +2,7 @@
 
 /* variableRow.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -2,7 +2,7 @@
 
 /* window.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/service.js
+++ b/tests/service.js
@@ -2,7 +2,7 @@
 
 /* service.js
  *
- * Copyright 2021 Martin Abente Lahaye
+ * Copyright 2021 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1,6 +1,6 @@
 /* testModels.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/src/testPathRow.js
+++ b/tests/src/testPathRow.js
@@ -2,7 +2,7 @@
 
 /* testPathRow.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/src/testPathsViewer.js
+++ b/tests/src/testPathsViewer.js
@@ -1,6 +1,6 @@
 /* testPathsViewer.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/src/utils.js
+++ b/tests/src/utils.js
@@ -4,7 +4,7 @@
 
 /* utils.js
  *
- * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2020 The Flatseal Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
- credit contributors
- remove current year as copyright in AboutDialog.js

---

Since Flatseal has few dozen of contributors, it's best to properly clarify copyright assignment and credit every contributor, as explained in the LinuxFoundation website:

https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/#:~:text=project%E2%80%99s%20name)%3A-,Copyright%20The%20XYZ%20Authors,to%20the%20XYZ%20project.,-These%20statements%20are

Secondly, I changed the following:
```diff
-     <property name="copyright">© 2020-2021 Martin Abente Lahaye</property>
+     <property name="copyright">© 2020 The Flatseal Authors</property>
```
because copyright assignment goes from a year and beyond. In this case, it's 2020 and beyond, so 2021 and 2022 are included. This will make maintaining this file much easier because we won't need to update it every year.