### PR TITLE
Highlight permissions changed by the user or globally

### DIFF
--- a/src/application.css
+++ b/src/application.css
@@ -49,6 +49,13 @@ row .content .path {
     background-color: @theme_bg_color;
 }
 
+row .status {
+    color: @theme_selected_bg_color;
+}
+row.activatable .status {
+    margin-right: 8px;
+}
+
 row .content .bus entry,
 row .content .variable entry,
 row .content .path entry {

--- a/src/com.github.tchx84.Flatseal.data.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.data.gresource.xml
@@ -8,6 +8,7 @@
     <file>widgets/busNameRow.ui</file>
     <file>widgets/docsViewer.ui</file>
     <file>widgets/menu.ui</file>
+    <file>widgets/overrideStatusIcon.ui</file>
     <file>widgets/pathRow.ui</file>
     <file>widgets/pathsViewer.ui</file>
     <file>widgets/permissionEntryRow.ui</file>

--- a/src/com.github.tchx84.Flatseal.src.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.src.gresource.xml
@@ -9,6 +9,7 @@
     <file>widgets/busNameRow.js</file>
     <file>widgets/detailsButton.js</file>
     <file>widgets/docsViewer.js</file>
+    <file>widgets/overrideStatusIcon.js</file>
     <file>widgets/pathRow.js</file>
     <file>widgets/pathsViewer.js</file>
     <file>widgets/permissionEntryRow.js</file>

--- a/src/com.github.tchx84.Flatseal.src.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.src.gresource.xml
@@ -22,6 +22,7 @@
     <file>widgets/window.js</file>
     <file>models/applications.js</file>
     <file>models/info.js</file>
+    <file>models/overrideStatus.js</file>
     <file>models/unsupported.js</file>
     <file>models/persistent.js</file>
     <file>models/permissions.js</file>

--- a/src/models/filesystemsOther.js
+++ b/src/models/filesystemsOther.js
@@ -143,6 +143,15 @@ var FlatpakFilesystemsOtherModel = GObject.registerClass({
         this._overrides = new Set([...added, ...removedOriginals, ...removedGlobals]);
     }
 
+    updateStatusProperty(proxy) {
+        const values = proxy.filesystems_other
+            .split(';')
+            .filter(p => p.length !== 0)
+            .map(p => this._getStatusForPermission(p));
+
+        proxy.set_property('filesystems-other-status', values.join(';'));
+    }
+
     updateProxyProperty(proxy) {
         const originals = [...this._originals]
             .filter(p => !this.constructor.isOverriden(this._filesystems._overrides, p))

--- a/src/models/overrideStatus.js
+++ b/src/models/overrideStatus.js
@@ -1,0 +1,25 @@
+/* exported FlatsealOverrideStatus */
+
+/* overrideStatus.js
+ *
+ * Copyright 2022 Martin Abente Lahaye
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var FlatsealOverrideStatus = {
+    ORIGINAL: 'original',
+    GLOBAL: 'global',
+    USER: 'user',
+};

--- a/src/models/persistent.js
+++ b/src/models/persistent.js
@@ -85,6 +85,15 @@ var FlatpakPersistentModel = GObject.registerClass({
         this._overrides = overrides;
     }
 
+    updateStatusProperty(proxy) {
+        const values = proxy.persistent
+            .split(';')
+            .filter(p => p.length !== 0)
+            .map(p => this._getStatusForPermission(p));
+
+        proxy.set_property('persistent-status', values.join(';'));
+    }
+
     updateProxyProperty(proxy) {
         const paths = new Set([...this._originals, ...this._globals, ...this._overrides]);
 

--- a/src/models/portals.js
+++ b/src/models/portals.js
@@ -293,6 +293,11 @@ var FlatpakPortalsModel = GObject.registerClass({
         }
     }
 
+    updateStatusProperty() {
+
+        /* does not apply to this backend */
+    }
+
     updateProxyProperty(proxy) {
         Object.entries(this.getPermissions()).forEach(([property, permission]) => {
             if (!this.isSupported(permission.table, permission.id)) {

--- a/src/models/unsupported.js
+++ b/src/models/unsupported.js
@@ -42,6 +42,11 @@ var FlatpakUnsupportedModel = GObject.registerClass({
         return false;
     }
 
+    updateStatusProperty() {
+
+        /* does not apply to this backend */
+    }
+
     updateProxyProperty() { // eslint-disable-line class-methods-use-this
         return false;
     }

--- a/src/models/variables.js
+++ b/src/models/variables.js
@@ -21,6 +21,7 @@
 const {GObject} = imports.gi;
 
 const {FlatpakSharedModel} = imports.models.shared;
+const {FlatsealOverrideStatus} = imports.models.overrideStatus;
 
 
 var FlatpakVariablesModel = GObject.registerClass({
@@ -101,6 +102,27 @@ var FlatpakVariablesModel = GObject.registerClass({
             });
 
         this._overrides = overrides;
+    }
+
+    _getStatusForPermission(variable) {
+        const [key] = variable.split(/[=](.*)/s);
+
+        let status = FlatsealOverrideStatus.ORIGINAL;
+        if (key in this._globals)
+            status = FlatsealOverrideStatus.GLOBAL;
+        if (key in this._overrides)
+            status = FlatsealOverrideStatus.USER;
+
+        return status;
+    }
+
+    updateStatusProperty(proxy) {
+        const values = proxy.variables
+            .split(';')
+            .filter(v => v.length !== 0)
+            .map(v => this._getStatusForPermission(v));
+
+        proxy.set_property('variables-status', values.join(';'));
     }
 
     updateProxyProperty(proxy) {

--- a/src/widgets/busNameRow.js
+++ b/src/widgets/busNameRow.js
@@ -20,6 +20,8 @@
 
 const {GObject, Gtk} = imports.gi;
 
+const {FlatsealOverrideStatusIcon} = imports.widgets.overrideStatusIcon;
+
 const _propFlags = GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT;
 
 /* https://dbus.freedesktop.org/doc/dbus-specification.html */
@@ -36,7 +38,7 @@ const _notValidMsg = _('This is not a valid option');
 var FlatsealBusNameRow = GObject.registerClass({
     GTypeName: 'FlatsealBusNameRow',
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/busNameRow.ui',
-    InternalChildren: ['entry', 'button', 'store', 'image'],
+    InternalChildren: ['entry', 'button', 'store', 'image', 'statusBox'],
     Properties: {
         text: GObject.ParamSpec.string(
             'text',
@@ -58,6 +60,9 @@ var FlatsealBusNameRow = GObject.registerClass({
 
         this._entry.connect('notify::text', this._changed.bind(this));
         this._button.connect('clicked', this._remove.bind(this));
+
+        this._statusIcon = new FlatsealOverrideStatusIcon();
+        this._statusBox.add(this._statusIcon);
     }
 
     _remove() {
@@ -96,5 +101,13 @@ var FlatsealBusNameRow = GObject.registerClass({
         if (this.text === text)
             return;
         this._entry.set_text(text);
+    }
+
+    get status() {
+        return this._statusIcon.status;
+    }
+
+    set status(status) {
+        this._statusIcon.status = status;
     }
 });

--- a/src/widgets/busNameRow.ui
+++ b/src/widgets/busNameRow.ui
@@ -74,6 +74,23 @@
       </packing>
     </child>
     <child>
+      <object class="GtkBox" id="statusBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -103,7 +120,7 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">False</property>
-        <property name="position">2</property>
+        <property name="position">3</property>
       </packing>
     </child>
     <style>

--- a/src/widgets/overrideStatusIcon.js
+++ b/src/widgets/overrideStatusIcon.js
@@ -1,0 +1,65 @@
+/* exported FlatsealOverrideStatusIcon OverrideStatus */
+
+/* overrideStatusIcon.js
+ *
+ * Copyright 2022 Martin Abente Lahaye
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const {GObject, Gtk} = imports.gi;
+const {FlatsealOverrideStatus} = imports.models.overrideStatus;
+
+const OverrideStatusDescription = {
+    global: _('Overridden globally'),
+    user: _('Overridden by the user'),
+};
+
+var FlatsealOverrideStatusIcon = GObject.registerClass({
+    GTypeName: 'FlatsealOverrideStatusIcon',
+    Template: 'resource:///com/github/tchx84/Flatseal/widgets/overrideStatusIcon.ui',
+    Properties: {
+        status: GObject.ParamSpec.string(
+            'status',
+            'status',
+            'status',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            FlatsealOverrideStatus.ORIGINAL,
+        ),
+    },
+}, class FlatsealOverrideStatusIcon extends Gtk.Box {
+    _init() {
+        super._init({});
+        this._status = FlatsealOverrideStatus.ORIGINAL;
+    }
+
+    set status(status) {
+        if (this._status === status)
+            return;
+
+        this._status = status;
+        if (status === FlatsealOverrideStatus.ORIGINAL) {
+            this.set_tooltip_text('');
+            this.visible = false;
+            return;
+        }
+
+        this.set_tooltip_text(OverrideStatusDescription[status]);
+        this.visible = true;
+    }
+
+    get status() {
+        return this._status;
+    }
+});

--- a/src/widgets/overrideStatusIcon.ui
+++ b/src/widgets/overrideStatusIcon.ui
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <template class="FlatsealOverrideStatusIcon" parent="GtkBox">
+    <property name="can-focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkImage">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="icon-name">dialog-warning-symbolic</property>
+        <property name="icon_size">2</property>
+        <style>
+          <class name="status"/>
+        </style>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/src/widgets/pathRow.js
+++ b/src/widgets/pathRow.js
@@ -19,6 +19,7 @@
  */
 
 const {GObject, Gtk} = imports.gi;
+const {FlatsealOverrideStatusIcon} = imports.widgets.overrideStatusIcon;
 
 const _propFlags = GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT;
 
@@ -75,7 +76,7 @@ const _notValidMsg = _('This is not a valid option');
 var FlatsealPathRow = GObject.registerClass({
     GTypeName: 'FlatsealPathRow',
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/pathRow.ui',
-    InternalChildren: ['entry', 'button', 'store', 'image'],
+    InternalChildren: ['entry', 'button', 'store', 'image', 'statusBox'],
     Properties: {
         text: GObject.ParamSpec.string(
             'text',
@@ -99,6 +100,9 @@ var FlatsealPathRow = GObject.registerClass({
     }
 
     _setup() {
+        this._statusIcon = new FlatsealOverrideStatusIcon();
+        this._statusBox.add(this._statusIcon);
+
         Object.keys(_options).forEach(option => {
             this._store.set(this._store.append(), [0], [option]);
             this._store.set(this._store.append(), [0], [`!${option}`]);
@@ -224,5 +228,13 @@ var FlatsealPathRow = GObject.registerClass({
 
         this._mode = value;
         this.notify('mode');
+    }
+
+    get status() {
+        return this._statusIcon.status;
+    }
+
+    set status(status) {
+        this._statusIcon.status = status;
     }
 });

--- a/src/widgets/pathRow.ui
+++ b/src/widgets/pathRow.ui
@@ -74,6 +74,26 @@
       </packing>
     </child>
     <child>
+      <object class="GtkBox" id="statusBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <placeholder/>
+        </child>
+        <style>
+          <class name="status"/>
+        </style>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -103,7 +123,7 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">False</property>
-        <property name="position">2</property>
+        <property name="position">3</property>
       </packing>
     </child>
     <style>

--- a/src/widgets/pathsViewer.js
+++ b/src/widgets/pathsViewer.js
@@ -19,6 +19,7 @@
  */
 
 const {GObject, Gtk} = imports.gi;
+const {FlatsealOverrideStatus} = imports.models.overrideStatus;
 
 const _propFlags = GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT;
 
@@ -33,9 +34,16 @@ var FlatsealPathsViewer = GObject.registerClass({
             'text',
             'text',
             _propFlags, ''),
+        status: GObject.ParamSpec.string(
+            'status',
+            'status',
+            'status',
+            _propFlags,
+            FlatsealOverrideStatus.ORIGINAL),
     },
 }, class FlatsealPathsViewer extends Gtk.Box {
     _init(rowClass) {
+        this._status = FlatsealOverrideStatus.ORIGINAL;
         super._init({});
         this._rowClass = rowClass;
     }
@@ -64,6 +72,24 @@ var FlatsealPathsViewer = GObject.registerClass({
 
             this.add(path);
         });
+
+        this._updateStatus();
+    }
+
+    _updateStatus() {
+        const statuses = this._status
+            .split(';')
+            .filter(s => s.length !== 0);
+        const rows = this._box.get_children()
+            .reverse();
+
+        /* if it's still out of sync, bail out */
+        if (statuses.length !== rows.length)
+            return;
+
+        rows.forEach((row, index) => {
+            row.status = statuses[index];
+        });
     }
 
     set text(text) {
@@ -87,6 +113,18 @@ var FlatsealPathsViewer = GObject.registerClass({
             .map(row => row.text)
             .reverse()
             .join(';');
+    }
+
+    set status(status) {
+        if (!this._box)
+            return;
+
+        this._status = status;
+        this._updateStatus();
+    }
+
+    get status() {
+        return this._status;
     }
 
     add(path) {

--- a/src/widgets/permissionEntryRow.js
+++ b/src/widgets/permissionEntryRow.js
@@ -63,4 +63,8 @@ var FlatsealPermissionEntryRow = GObject.registerClass({
     get content() {
         return this._content;
     }
+
+    get status() {
+        return this._content;
+    }
 });

--- a/src/widgets/permissionSwitchRow.js
+++ b/src/widgets/permissionSwitchRow.js
@@ -19,12 +19,13 @@
  */
 
 const {GObject, Handy} = imports.gi;
+const {FlatsealOverrideStatusIcon} = imports.widgets.overrideStatusIcon;
 
 
 var FlatsealPermissionSwitchRow = GObject.registerClass({
     GTypeName: 'FlatsealPermissionSwitchRow',
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/permissionSwitchRow.ui',
-    InternalChildren: ['content'],
+    InternalChildren: ['content', 'statusBox'],
 }, class FlatsealPermissionSwitchRow extends Handy.ActionRow {
     _init(description, permission, content) {
         super._init({});
@@ -32,6 +33,9 @@ var FlatsealPermissionSwitchRow = GObject.registerClass({
         this.set_subtitle(permission);
         this._content.set_state(content);
         this.connect('notify::sensitive', this._update.bind(this));
+
+        this._statusIcon = new FlatsealOverrideStatusIcon();
+        this._statusBox.add(this._statusIcon);
     }
 
     _update() {
@@ -43,5 +47,9 @@ var FlatsealPermissionSwitchRow = GObject.registerClass({
 
     get content() {
         return this._content;
+    }
+
+    get status() {
+        return this._statusIcon;
     }
 });

--- a/src/widgets/permissionSwitchRow.ui
+++ b/src/widgets/permissionSwitchRow.ui
@@ -5,14 +5,56 @@
   <requires lib="libhandy" version="0.0"/>
   <template class="FlatsealPermissionSwitchRow" parent="HdyActionRow">
     <property name="visible">True</property>
+    <property name="sensitive">False</property>
     <property name="can-focus">True</property>
     <property name="activatable-widget">content</property>
     <child>
-      <object class="GtkSwitch" id="content">
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="halign">end</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
         <property name="valign">center</property>
+        <child>
+          <object class="GtkBox" id="statusBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="valign">center</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkSwitch" id="content">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
     </child>
   </template>

--- a/src/widgets/relativePathRow.js
+++ b/src/widgets/relativePathRow.js
@@ -21,6 +21,7 @@
 const {GObject, Gtk} = imports.gi;
 
 const {persistent} = imports.models;
+const {FlatsealOverrideStatusIcon} = imports.widgets.overrideStatusIcon;
 
 const _propFlags = GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT;
 
@@ -35,7 +36,7 @@ const _notValidMsg = _('This is not a valid option');
 var FlatsealRelativePathRow = GObject.registerClass({
     GTypeName: 'FlatsealRelativePathRow',
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/relativePathRow.ui',
-    InternalChildren: ['entry', 'button', 'store', 'image'],
+    InternalChildren: ['entry', 'button', 'store', 'image', 'statusBox'],
     Properties: {
         text: GObject.ParamSpec.string(
             'text',
@@ -57,6 +58,9 @@ var FlatsealRelativePathRow = GObject.registerClass({
 
         this._entry.connect('notify::text', this._changed.bind(this));
         this._button.connect('clicked', this._remove.bind(this));
+
+        this._statusIcon = new FlatsealOverrideStatusIcon();
+        this._statusBox.add(this._statusIcon);
     }
 
     _remove() {
@@ -107,5 +111,13 @@ var FlatsealRelativePathRow = GObject.registerClass({
         if (this.text === text)
             return;
         this._entry.set_text(text);
+    }
+
+    get status() {
+        return this._statusIcon.status;
+    }
+
+    set status(status) {
+        this._statusIcon.status = status;
     }
 });

--- a/src/widgets/relativePathRow.ui
+++ b/src/widgets/relativePathRow.ui
@@ -74,6 +74,23 @@
       </packing>
     </child>
     <child>
+      <object class="GtkBox" id="statusBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -103,7 +120,7 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">False</property>
-        <property name="position">2</property>
+        <property name="position">3</property>
       </packing>
     </child>
     <style>

--- a/src/widgets/variableRow.js
+++ b/src/widgets/variableRow.js
@@ -20,6 +20,8 @@
 
 const {GObject, Gtk} = imports.gi;
 
+const {FlatsealOverrideStatusIcon} = imports.widgets.overrideStatusIcon;
+
 const _propFlags = GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT;
 
 var validity = {
@@ -33,7 +35,7 @@ const _notValidMsg = _('This is not a valid option');
 var FlatsealVariableRow = GObject.registerClass({
     GTypeName: 'FlatsealVariableRow',
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/variableRow.ui',
-    InternalChildren: ['entry', 'button', 'store', 'image'],
+    InternalChildren: ['entry', 'button', 'store', 'image', 'statusBox'],
     Properties: {
         text: GObject.ParamSpec.string(
             'text',
@@ -55,6 +57,9 @@ var FlatsealVariableRow = GObject.registerClass({
 
         this._entry.connect('notify::text', this._changed.bind(this));
         this._button.connect('clicked', this._remove.bind(this));
+
+        this._statusIcon = new FlatsealOverrideStatusIcon();
+        this._statusBox.add(this._statusIcon);
     }
 
     _remove() {
@@ -93,5 +98,13 @@ var FlatsealVariableRow = GObject.registerClass({
         if (this.text === text)
             return;
         this._entry.set_text(text);
+    }
+
+    get status() {
+        return this._statusIcon.status;
+    }
+
+    set status(status) {
+        this._statusIcon.status = status;
     }
 });

--- a/src/widgets/variableRow.ui
+++ b/src/widgets/variableRow.ui
@@ -74,6 +74,23 @@
       </packing>
     </child>
     <child>
+      <object class="GtkBox" id="statusBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -103,7 +120,7 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">False</property>
-        <property name="position">2</property>
+        <property name="position">3</property>
       </packing>
     </child>
     <style>

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -195,7 +195,13 @@ var FlatsealWindow = GObject.registerClass({
 
             row.sensitive = p.supported;
             lastPrefsGroup.add(row);
+
             this._permissions.bind_property(p.property, row.content, property, _bindFlags);
+
+            if (!row.status)
+                return;
+
+            this._permissions.bind_property(p.statusProperty, row.status, 'status', _bindFlags);
         });
 
         this.connect('delete-event', this._saveSettings.bind(this));

--- a/tests/content/statuses/flatpak/overrides/com.test.Statuses
+++ b/tests/content/statuses/flatpak/overrides/com.test.Statuses
@@ -1,0 +1,11 @@
+[Context]
+sockets=x11
+persistent=.test3
+filesystems=~/test3
+
+[Environment]
+TEST2=override
+
+[Session Bus Policy]
+org.test.Service-5=talk
+org.test.Service-6=own

--- a/tests/content/statuses/flatpak/overrides/global
+++ b/tests/content/statuses/flatpak/overrides/global
@@ -1,0 +1,12 @@
+[Context]
+shared=unsupported
+sockets=!x11;wayland;
+persistent=.test2
+filesystems=~/test2
+
+[Environment]
+TEST1=global
+
+[Session Bus Policy]
+org.test.Service-3=talk
+org.test.Service-4=own

--- a/tests/content/system/flatpak/app/com.test.Statuses/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Statuses/current/active/metadata
@@ -1,0 +1,13 @@
+[Context]
+sockets=x11;!wayland;cups;
+persistent=.test1
+filesystems=~/test1
+
+[Environment]
+TEST0=original
+TEST1=original
+TEST2=original
+
+[Session Bus Policy]
+org.test.Service-1=talk
+org.test.Service-2=own

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -52,6 +52,7 @@ const _trailingSemicolonId = 'com.test.TrailingSemicolon';
 const _filesystemWithMode = 'com.test.FilesystemWithMode';
 const _globalAppId = 'com.test.Global';
 const _globalRestoredAppId = 'com.test.GlobalRestored';
+const _statusesAppId = 'com.test.Statuses';
 
 const _flatpakInfo = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info']);
 const _flatpakInfoOld = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info.old']);
@@ -60,6 +61,7 @@ const _flatpakInfoNew = GLib.build_filenamev(['..', 'tests', 'content', '.flatpa
 const _system = GLib.build_filenamev(['..', 'tests', 'content', 'system', 'flatpak']);
 const _user = GLib.build_filenamev(['..', 'tests', 'content', 'user', 'flatpak']);
 const _global = GLib.build_filenamev(['..', 'tests', 'content', 'global', 'flatpak']);
+const _statuses = GLib.build_filenamev(['..', 'tests', 'content', 'statuses', 'flatpak']);
 const _tmp = GLib.build_filenamev([GLib.DIR_SEPARATOR_S, 'tmp']);
 const _none = GLib.build_filenamev([GLib.DIR_SEPARATOR_S, 'dev', 'null']);
 const _overrides = GLib.build_filenamev([_tmp, 'overrides']);
@@ -1243,5 +1245,19 @@ describe('Model', function() {
         expect(permissions.filesystems_other).toEqual('~/test4');
         expect(permissions.session_talk).toEqual('org.test.Service-4');
         expect(permissions.session_own).toEqual('org.test.Service-5');
+    });
+
+    it('sets proper override statuses', function() {
+        GLib.setenv('FLATPAK_USER_DIR', _statuses, true);
+        permissions.appId = _statusesAppId;
+
+        expect(permissions.sockets_cups_status).toEqual('original');
+        expect(permissions.sockets_wayland_status).toEqual('global');
+        expect(permissions.sockets_x11_status).toEqual('user');
+        expect(permissions.variables_status).toEqual('original;global;user');
+        expect(permissions.persistent_status).toEqual('original;global;user');
+        expect(permissions.filesystems_other_status).toEqual('original;global;user');
+        expect(permissions.session_talk_status).toEqual('original;global;user');
+        expect(permissions.session_own_status).toEqual('original;global;user');
     });
 });


### PR DESCRIPTION
With this, Flatseal will not only show the current set of granted permissions but will also show which of those permissions are overrides and where these overrides came from, e.g. from the user or from global overrides.

Closes #279