### PR TITLE
Save only valid D-Bus Names

### DIFF
--- a/src/models/sessionBus.js
+++ b/src/models/sessionBus.js
@@ -23,12 +23,15 @@ const {GObject} = imports.gi;
 const {FlatpakSharedModel} = imports.models.shared;
 const {FlatsealOverrideStatus} = imports.models.overrideStatus;
 
+/* https://dbus.freedesktop.org/doc/dbus-specification.html */
+const EXP = /^(([A-Z]|[a-z]|[0-9]|_|-)+)(\.(([A-Z]|[a-z]|[0-9]|_|-)+))+(\.\*){0,1}$/;
 
 var FlatpakSessionBusModel = GObject.registerClass({
     GTypeName: 'FlatpakSessionBusModel',
 }, class FlatpakSessionBusModel extends FlatpakSharedModel {
     _init() {
         super._init({});
+        this._expression = new RegExp(EXP);
     }
 
     getPermissions() {
@@ -180,7 +183,9 @@ var FlatpakSessionBusModel = GObject.registerClass({
     saveToKeyFile(keyFile) {
         const group = this.constructor.getGroup();
         Object.entries(this._overrides).forEach(([key, value]) => {
-            keyFile.set_value(group, key, value);
+            if (this._expression.test(key)) {
+                keyFile.set_value(group, key, value);
+            }
         });
     }
 


### PR DESCRIPTION
Flatpak has a Bug that Apps didn't start when you give them Permission to talk to a invalid D-Dbus name (flatpak/flatpak#4940). Until this is fixed, it is better to block writing invalid D-Bus names. If someone does accidental use a invalid D-Bus name for global and ignore the warning, no Flatpak App will start until the problem is solved with the Flatpak cli or the overrides file is deleted. 