### PR TITLE
overrideStatusIcon: Use different colors for user and global overrides

### DIFF
--- a/src/application.css
+++ b/src/application.css
@@ -52,6 +52,9 @@ row .content .path {
 row .status {
     color: @theme_selected_bg_color;
 }
+row .status.global {
+    color: @insensitive_fg_color;
+}
 row.activatable .status {
     margin-right: 8px;
 }

--- a/src/widgets/overrideStatusIcon.js
+++ b/src/widgets/overrideStatusIcon.js
@@ -48,6 +48,12 @@ var FlatsealOverrideStatusIcon = GObject.registerClass({
         if (this._status === status)
             return;
 
+        const context = this.get_style_context();
+        if (context.has_class(FlatsealOverrideStatus.USER))
+            context.remove_class(FlatsealOverrideStatus.USER);
+        else if (context.has_class(FlatsealOverrideStatus.GLOBAL))
+            context.remove_class(FlatsealOverrideStatus.GLOBAL);
+
         this._status = status;
         if (status === FlatsealOverrideStatus.ORIGINAL) {
             this.set_tooltip_text('');
@@ -57,6 +63,7 @@ var FlatsealOverrideStatusIcon = GObject.registerClass({
 
         this.set_tooltip_text(OverrideStatusDescription[status]);
         this.visible = true;
+        context.add_class(status);
     }
 
     get status() {

--- a/src/widgets/overrideStatusIcon.ui
+++ b/src/widgets/overrideStatusIcon.ui
@@ -13,9 +13,6 @@
         <property name="valign">center</property>
         <property name="icon-name">dialog-warning-symbolic</property>
         <property name="icon_size">2</property>
-        <style>
-          <class name="status"/>
-        </style>
       </object>
       <packing>
         <property name="expand">True</property>
@@ -23,5 +20,8 @@
         <property name="position">0</property>
       </packing>
     </child>
+    <style>
+      <class name="status"/>
+    </style>
   </template>
 </interface>


### PR DESCRIPTION
Currently both user and global overrides use the same icon color which is confusing. So, with this change these use two different colors.