### PR TITLE
Added information for RHEL 9 compability 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,15 @@ For more details please visit the [documentation](./DOCUMENTATION.md) page.
 
 ### RHEL 9 Compatiblity [Almalinux and RockyLinux, etc]
 In case the application font texts are not displayed correctly please use the
+
+'gsettings set org.gnome.desktop.interface font-name "DejaVu Sans Regular 10"'  where the 10 is the font size
+  
+or
+
 `gnome-tweaks` package to **change the font for Interface Text from the default to
 something silimar like** `dejavu sans regular`.
+
+
 
 
 ## Get it

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more details please visit the [documentation](./DOCUMENTATION.md) page.
 ### RHEL 9 Compatiblity [Almalinux and RockyLinux, etc]
 In case the application font texts are not displayed correctly please use the
 
-'gsettings set org.gnome.desktop.interface font-name "DejaVu Sans Regular 10"'  where the 10 is the font size
+`gsettings set org.gnome.desktop.interface font-name "DejaVu Sans Regular 10"`  where the 10 is the font size
   
 or
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simply launch Flatseal, select an application and modify its permissions. Restar
 For more details please visit the [documentation](./DOCUMENTATION.md) page.
 
 ### RHEL 9 Compatiblity [Almalinux and RockyLinux, etc]
-In case the application font texts are not displayed correctly please use the **gnome-tweaks package to change the font for Interface Text from the default to something silumar like** 'dejavu sans regular'
+In case the application font texts are not displayed correctly please use the **gnome-tweaks package to change the font for Interface Text from the default to something silumar like** `dejavu sans regular`
 
 
 ## Get it

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simply launch Flatseal, select an application and modify its permissions. Restar
 For more details please visit the [documentation](./DOCUMENTATION.md) page.
 
 ### RHEL 9 Compatiblity [Almalinux and RockyLinux, etc]
-In case the application font texts are not displayed correctly please use the **gnome-tweaks package to change the font for Interface Text from the default to something silumar like** `dejavu sans regular`
+In case the application font texts are not displayed correctly please use the **gnome-tweaks package to change the font for Interface Text from the default to something silumar like** ```dejavu sans regular```
 
 
 ## Get it

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Simply launch Flatseal, select an application and modify its permissions. Restar
 
 For more details please visit the [documentation](./DOCUMENTATION.md) page.
 
-### RHEL 9 Compatible so Almalinux 9 and RockyLinux
-In case your fonts are not displayed correctly please use the **gnome-tweaks package to change the font for Interface Text from the default to something silumar like** 'dejavu sans regular'
+### RHEL 9 Compatiblity [Almalinux and RockyLinux, etc]
+In case the application font texts are not displayed correctly please use the **gnome-tweaks package to change the font for Interface Text from the default to something silumar like** 'dejavu sans regular'
 
 
 ## Get it

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Simply launch Flatseal, select an application and modify its permissions. Restar
 
 For more details please visit the [documentation](./DOCUMENTATION.md) page.
 
+### RHEL 9 Compatible so Almalinux 9 and RockyLinux
+In case your fonts are not displayed correctly please use the **gnome-tweaks package to change the font for Interface Text from the default to something silumar like** 'dejavu sans regular'
+
+
 ## Get it
 
 [<img width="240" src="https://flathub.org/assets/badges/flathub-badge-i-en.png">](https://flathub.org/apps/details/com.github.tchx84.Flatseal)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simply launch Flatseal, select an application and modify its permissions. Restar
 For more details please visit the [documentation](./DOCUMENTATION.md) page.
 
 ### RHEL 9 Compatiblity [Almalinux and RockyLinux, etc]
-In case the application font texts are not displayed correctly please use the **gnome-tweaks package to change the font for Interface Text from the default to something silumar like** ```dejavu sans regular```
+In case the application font texts are not displayed correctly please use the `gnome-tweaks` package to **change the font for Interface Text from the default to something silumar like** `dejavu sans regular`
 
 
 ## Get it

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Simply launch Flatseal, select an application and modify its permissions. Restar
 For more details please visit the [documentation](./DOCUMENTATION.md) page.
 
 ### RHEL 9 Compatiblity [Almalinux and RockyLinux, etc]
-In case the application font texts are not displayed correctly please use the `gnome-tweaks` package to **change the font for Interface Text from the default to something silumar like** `dejavu sans regular`
+In case the application font texts are not displayed correctly please use the
+`gnome-tweaks` package to **change the font for Interface Text from the default to
+something silimar like** `dejavu sans regular`.
 
 
 ## Get it


### PR DESCRIPTION
updated README.md

preview : https://github.com/rizajur/Flatseal/blob/master/README.md

 for dirty workaround regarding broken font implementation of OS default interface font (Gnome 40.1)
would be cool if we could change the font family to something dejavu related in the future depending on the availability of the required packages in the different operating systems or if embedding is best option