### PR TITLE
WIP: relativePathRow: Fix regular expression for validation

### DIFF
--- a/src/widgets/relativePathRow.js
+++ b/src/widgets/relativePathRow.js
@@ -54,7 +54,7 @@ var FlatsealRelativePathRow = GObject.registerClass({
     }
 
     _setup() {
-        this._expression = new RegExp(/.*\S.*/);
+        this._expression = new RegExp(/^[^\n]*$/);
 
         this._entry.connect('notify::text', this._changed.bind(this));
         this._button.connect('clicked', this._remove.bind(this));

--- a/tests/content/system/flatpak/app/com.test.Malformed/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Malformed/current/active/metadata
@@ -1,0 +1,2 @@
+[Context]
+shared=network;

--- a/tests/content/user/flatpak/overrides/com.test.Malformed
+++ b/tests/content/user/flatpak/overrides/com.test.Malformed
@@ -1,0 +1,1 @@
+malformed

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -54,6 +54,7 @@ const _resetModeId = 'com.test.ResetMode';
 const _globalAppId = 'com.test.Global';
 const _globalRestoredAppId = 'com.test.GlobalRestored';
 const _statusesAppId = 'com.test.Statuses';
+const _malformedAppId = 'com.test.Malformed';
 
 const _flatpakInfo = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info']);
 const _flatpakInfoOld = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info.old']);
@@ -1388,5 +1389,14 @@ describe('Model', function() {
         });
 
         update();
+    });
+
+    it('handles malformed overrides', function() {
+        spyOn(permissions, 'emit');
+
+        GLib.setenv('FLATPAK_USER_DIR', _user, true);
+        permissions.appId = _malformedAppId;
+
+        expect(permissions.emit.calls.first().args).toEqual(['failed']);
     });
 });


### PR DESCRIPTION
flatpak-override --persist option can take basically any string, so there isn't much to validate here, except one string that can break the config files, e.g. linebreaks.

Closes #558