### PR TITLE
permissions: Reset monitor guard when switching applications

### DIFF
--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -325,6 +325,7 @@ var FlatpakPermissionsModel = GObject.registerClass({
 
         this._monitors = [];
         this._monitorsDelayedHandlerId = 0;
+        this._changedbyUser = false;
     }
 
     _delayMonitorsChanged() {


### PR DESCRIPTION
Without resetting this guard, any external changes made to the newly-selected application could potentually have been ignored, once.

This would only happen when switching extremely fast between applications.