### PR TITLE
Add "override" keyword to desktop file

### DIFF
--- a/data/com.github.tchx84.Flatseal.desktop.in
+++ b/data/com.github.tchx84.Flatseal.desktop.in
@@ -11,4 +11,4 @@ Comment=Manage Flatpak permissions
 Icon=com.github.tchx84.Flatseal
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;
-Keywords=seal;sandbox;
+Keywords=seal;sandbox;override;


### PR DESCRIPTION
Flatseal is a fancy interface for `flatpak override` but the word
“override” did not previously appear in its metadata.
