### PR TITLE
Fix french translation of network

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -233,7 +233,7 @@ msgstr "Les données du portail n’ont pas encore été configurées"
 
 #: src/models/shared.js:39
 msgid "Network"
-msgstr "Réseau sans fil"
+msgstr "Réseau"
 
 #: src/models/shared.js:46
 msgid "Inter-process communications"


### PR DESCRIPTION
The previous translation of "Network" in the French translation file is « Réseau sans fil », which meant "Wireless network". This commit update the translation to a more accurate one.