### PR TITLE
models: update for AppStream 1.0

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 pkgdatadir = join_paths(get_option('datadir'), meson.project_name())
 gnome = import('gnome')
 
+dependency('appstream', version : '>= 1.0')
 dependency('libadwaita-1', version : '>= 1.5')
 dependency('webkitgtk-6.0', version : '>= 2.40')
 

--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -326,14 +326,18 @@ var FlatpakApplicationsModel = GObject.registerClass({
         if (component.get_name())
             appdata.name = component.get_name();
 
-        if (component.get_developer_name())
-            appdata.author = component.get_developer_name();
+        const developer = component.get_developer();
+        if (developer && developer.get_name())
+            appdata.author = developer.get_name();
 
         const launchable = component.get_launchable(AppStream.LaunchableKind.DESKTOP_ID);
         if (launchable && launchable.get_entries())
             [appdata.launchable] = launchable.get_entries();
 
-        const [release] = component.get_releases();
+        const releaselist = component.get_releases_plain();
+        if (!releaselist)
+            return appdata;
+        const [release] = releaselist.get_entries();
         if (!release)
             return appdata;
 


### PR DESCRIPTION
AppStream 1.0.0 includes several API breaks compared to the previous 0.16 (and earlier) versions, but unfortunately both versions used the same 1.0 GI version, so there is no way to differentiate at import time. ~~As such, try/catch is used to fall back to the 0.16 API where they differ.~~ Therefore, enforce the requirement during the build to make this clear.
