### PR TITLE
widgets: Always update path entries

### DIFF
--- a/src/widgets/pathsViewer.js
+++ b/src/widgets/pathsViewer.js
@@ -97,9 +97,6 @@ var FlatsealPathsViewer = GObject.registerClass({
             return;
         }
 
-        if (text === this.text)
-            return;
-
         this._update(text);
         this.notify('text');
     }


### PR DESCRIPTION
Persistent permissions can't be negated. Therefore when a persistent override is added globally, these overrides shouldn't be removed from specific apps

What happens here  is that, Flatseal disables the remove  button for the first app that is loaded and later, when switching to the global overrides view, since both have the same persistent value the button remains disabled.

Closes #631