### PR TITLE
models: Refine checks for strict filesystem overrides

### DIFF
--- a/src/models/filesystemsOther.js
+++ b/src/models/filesystemsOther.js
@@ -103,11 +103,7 @@ var FlatpakFilesystemsOtherModel = GObject.registerClass({
     }
 
     static isStrictlyOverriden(set, value) {
-        const path = value.replace('!', '');
-
-        return (
-            set.has(path) ||
-            set.has(`!${path}`));
+        return set.has(this.negate(value));
     }
 
     static isResetOverride(value) {


### PR DESCRIPTION
Redudant overrides were considered strict overrides, which caused the same redudant overrides to not be displayed, which is wrong.

e.g., /dir in global and /dir in overrides should be displayed.