### PR TITLE
Add screenshot portal permission row

### DIFF
--- a/src/models/portals.js
+++ b/src/models/portals.js
@@ -79,6 +79,7 @@ var FlatpakPortalsModel = GObject.registerClass({
         this._devicesspeakersSupported = null;
         this._devicescameraSupported = null;
         this._locationlocationSupported = null;
+        this._screenshotscreenshotSupported = null;
 
         this._backgroundbackgroundReason = '';
         this._notificationsnotificationReason = '';
@@ -86,6 +87,7 @@ var FlatpakPortalsModel = GObject.registerClass({
         this._devicesspeakersReason = '';
         this._devicescameraReason = '';
         this._locationlocationReason = '';
+        this._screenshotscreenshotReason = '';
 
         this._info = info.getDefault();
         this._appId = '';
@@ -172,6 +174,16 @@ var FlatpakPortalsModel = GObject.registerClass({
                 id: 'location',
                 allowed: ['EXACT', '0'],
                 disallowed: ['NONE', '0'],
+            },
+            'portals-screenshot': {
+                supported: this.isSupported('screenshot', 'screenshot'),
+                description: _('Screenshot'),
+                value: this.constructor.getDefault(),
+                example: _('Take pictures of the screen at any time'),
+                table: 'screenshot',
+                id: 'screenshot',
+                allowed: ['yes'],
+                disallowed: ['no'],
             },
         };
     }


### PR DESCRIPTION
~Some apps (like flameshot https://github.com/flameshot-org/flameshot/issues/2868#issuecomment-2397392428) require users to set the screenshot portal permission manually. Flatseal seems like a right place for this dial.~

This allows users to revoke previously given permission. (it was previously posible in gnome control center, but having it in one place in Flatseal would be cool too)

![image](https://github.com/user-attachments/assets/b51c6e7d-2b0e-445b-b12f-323c961675a7)
