### PR TITLE
Typo in french translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -110,7 +110,7 @@ msgstr "Tous les périphériques (e.g. webcam)"
 
 #: src/models/devices.js:90
 msgid "List of devices available in the sandbox"
-msgstr "Liste des périphériques disponible dans le sac à sable"
+msgstr "Liste des périphériques disponible dans le bac à sable"
 
 #: src/models/features.js:37
 msgid "Development syscalls (e.g. ptrace)"


### PR DESCRIPTION
The typo made that it read sand bag instead of sand box.

I don't know if this is the correct way to contribute to the translation of flatseal.