### PR TITLE
Implement a --show-app CLI flag

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -43,7 +43,7 @@ var FlatsealApplication = GObject.registerClass({
             null,
             GLib.OptionFlags.NONE,
             GLib.OptionArg.STRING,
-            'A custom flag for my app',
+            'Show a specific application entry, by providing its ID',
             null);
 
         this.connect("command-line", this._cliArgHandler.bind(this));

--- a/src/application.js
+++ b/src/application.js
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const {GObject, Gtk, Gio, Adw} = imports.gi;
+const {GObject, Gtk, Gio, GLib, Adw} = imports.gi;
 
 const {FlatsealWindow} = imports.widgets.window;
 const {showAboutDialog} = imports.widgets.aboutDialog;
@@ -32,17 +32,31 @@ var FlatsealApplication = GObject.registerClass({
     _init() {
         super._init({
             application_id: 'com.github.tchx84.Flatseal',
-            flags: Gio.ApplicationFlags.FLAGS_NONE,
+            flags: Gio.ApplicationFlags.HANDLES_COMMAND_LINE,
             resource_base_path: '/com/github/tchx84/Flatseal/',
         });
 
         this._window = null;
+
+        this.add_main_option(
+            'show-app',
+            null,
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.STRING,
+            'A custom flag for my app',
+            null);
+
+        this.connect("command-line", this._cliArgHandler.bind(this));
     }
 
     _cliArgHandler(_app, gCommandLine) {
         this.vfunc_activate();
         try {
             const options = gCommandLine.get_options_dict();
+            if (options.contains('show-app')) {
+                const appId = options.lookup_value("show-app", null).get_string()[0];
+                return this._window.showAppId(appId);
+            }
         } catch (error) {
             logError(error);
             return 1;

--- a/src/application.js
+++ b/src/application.js
@@ -39,6 +39,17 @@ var FlatsealApplication = GObject.registerClass({
         this._window = null;
     }
 
+    _cliArgHandler(_app, gCommandLine) {
+        this.vfunc_activate();
+        try {
+            const options = gCommandLine.get_options_dict();
+        } catch (error) {
+            logError(error);
+            return 1;
+        }
+        return 0;
+    }
+
     _displayHelp() {
         const launcher = new Gtk.UriLauncher();
         launcher.uri = 'https://github.com/tchx84/flatseal';

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -399,6 +399,22 @@ var FlatsealWindow = GObject.registerClass({
         this._permissions.undo();
     }
 
+    showAppId(appId) {
+        for (const row of Array.from(this._applicationsListBox)) {
+            if (!row.visible)
+                continue;
+
+            if (!row instanceof FlatsealApplicationRow)
+                continue;
+
+            if (row.appId === appId) {
+                this._activateApplication(this._applicationsListBox, row);
+                return 0;
+            }
+        }
+        return 1;
+    }
+
     vfunc_close_request() {
         this._settings.saveWindowState(this);
         this._shutdown();


### PR DESCRIPTION
## What this adds:
`flatseal --show-app org.app.Name`
- Adds a new --show-app command-line flag, which takes a Flatpak's appID.
- If the supplied ID matches an installed app, the UI will switch to showing that app.
- If no match is found, nothing happens. 
- The flag can be invoked at startup of Flatseal, or while Flatseal is running, and will behave the same.

There is no way to show the Global section, however I can add this if it is desired. Also, I can change the behavior of a non-matching provided ID, if you'd like that to behave differently than doing nothing.

The new flag shows up in the default --help output, with a description.

I believe I have followed Flatseal's coding style to the best of my abilities, but I can always refine what I've added!

## Why I think this should be added:
I believe it would be handy for Flatseal to be able to be opened to a specific application, to allow it to be called from other apps or scripts. I am the developer of [Warehouse](https://github.com/flattool/warehouse), and I would like to be able to launch Flatseal to a specific app via a button in the UI.