### PR TITLE
feat: add device=usb permission toggle

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -64,6 +64,7 @@ GPU acceleration | Toggle | Allow the application to access the graphics direct 
 Input devices | Toggle | Allow input device access. <br /> <br /> Note that raw and virtual input devices could still require [All devices](#device) | `--device=input` and `--nodevice=input`
 Virtualization | Toggle | Allow the application to support virtualization. | `--device=kvm` and `--nodevice=kvm`
 Shared memory | Toggle | Allow the application to access shared memory. | `--device=shm` and `--nodevice=shm`
+USB devices | Toggle | Allow raw USB device access. | `--device=usb` and `--nodevice=usb`
 All devices | Toggle | Allow the application to access all devices, such as webcam and external devices. <br /> <br /> For example, if it's disabled for Element, it will no longer be possible to do video calls with this application. | `--device=all` and `--nodevice=all`
 
 ### Allow

--- a/help/C/index.html
+++ b/help/C/index.html
@@ -248,6 +248,12 @@
 <td><code>--device=shm</code> and <code>--nodevice=shm</code></td>
 </tr>
 <tr class="odd">
+<td>USB devices</td>
+<td>Toggle</td>
+<td>Allow raw USB device access.</td>
+<td><code>--device=usb</code> and <code>--nodevice=usb</code></td>
+</tr>
+<tr class="even">
 <td>All devices</td>
 <td>Toggle</td>
 <td>Allow the application to access all devices, such as webcam and external devices. <br /> <br /> For example, if it’s disabled for Element, it will no longer be possible to do video calls with this application.</td>

--- a/src/models/devices.js
+++ b/src/models/devices.js
@@ -60,6 +60,13 @@ var FlatpakDevicesModel = GObject.registerClass({
                 value: this.constructor.getDefault(),
                 example: 'device=shm',
             },
+            'devices-usb': {
+                supported: this._info.supports('1.15.11'),
+                description: _('USB devices'),
+                option: 'usb',
+                value: this.constructor.getDefault(),
+                example: 'device=usb',
+            },
             'devices-all': {
                 supported: this._info.supports('0.6.6'),
                 description: _('All devices (e.g. webcam)'),

--- a/tests/content/system/flatpak/app/com.test.Basic/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Basic/current/active/metadata
@@ -1,7 +1,7 @@
 [Context]
 shared=network;ipc;
 sockets=x11;fallback-x11;wayland;pulseaudio;system-bus;session-bus;ssh-auth;pcsc;cups;gpg-agent;inherit-wayland-socket;
-devices=dri;input;kvm;shm;all;
+devices=dri;input;kvm;shm;usb;all;
 features=bluetooth;devel;multiarch;canbus;per-app-dev-shm;
 filesystems=host;host-os;host-etc;home;~/test;
 persistent=.test;

--- a/tests/content/system/flatpak/app/com.test.BasicNegated/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.BasicNegated/current/active/metadata
@@ -1,7 +1,7 @@
 [Context]
 shared=!network;!ipc;
 sockets=!x11;!fallback-x11;!wayland;!pulseaudio;!system-bus;!session-bus;!ssh-auth;!pcsc;!cups;!gpg-agent;!inherit-wayland-socket;
-devices=!dri;!input;!kvm;!shm;!all;
+devices=!dri;!input;!kvm;!shm;!usb;!all;
 features=!bluetooth;!devel;!multiarch;!canbus;!per-app-dev-shm;
 filesystems=!host;!host-os;!host-etc;!home;!~/test;
 persistent=tset.

--- a/tests/content/user/flatpak/overrides/com.test.Basic
+++ b/tests/content/user/flatpak/overrides/com.test.Basic
@@ -1,7 +1,7 @@
 [Context]
 shared=!network;!ipc;
 sockets=!x11;!fallback-x11;!wayland;!pulseaudio;!system-bus;!session-bus;!ssh-auth;!pcsc;!cups;!gpg-agent;!inherit-wayland-socket;
-devices=!dri;!input;!kvm;!shm;!all;
+devices=!dri;!input;!kvm;!shm;!usb;!all;
 features=!bluetooth;!devel;!multiarch;!canbus;!per-app-dev-shm;
 filesystems=!host;!host-os;!host-etc;!home;!~/test;
 persistent=tset.

--- a/tests/content/user/flatpak/overrides/com.test.BasicNegated
+++ b/tests/content/user/flatpak/overrides/com.test.BasicNegated
@@ -1,7 +1,7 @@
 [Context]
 shared=network;ipc;
 sockets=x11;fallback-x11;wayland;pulseaudio;system-bus;session-bus;ssh-auth;pcsc;cups;gpg-agent;inherit-wayland-socket;
-devices=dri;input;kvm;shm;all;
+devices=dri;input;kvm;shm;usb;all;
 features=bluetooth;devel;multiarch;canbus;per-app-dev-shm;
 filesystems=host;host-os;host-etc;home;~/test;
 persistent=.test;

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -33,7 +33,7 @@ const {
 
 setup();
 
-const _totalPermissions = 40;
+const _totalPermissions = 41;
 
 const _basicAppId = 'com.test.Basic';
 const _basicNegatedAppId = 'com.test.BasicNegated';
@@ -184,6 +184,7 @@ describe('Model', function() {
         expect(permissionsDefault.devices_input).toBe(true);
         expect(permissionsDefault.devices_kvm).toBe(true);
         expect(permissionsDefault.devices_shm).toBe(true);
+        expect(permissionsDefault.devices_usb).toBe(true);
         expect(permissionsDefault.devices_all).toBe(true);
         expect(permissionsDefault.features_bluetooth).toBe(true);
         expect(permissionsDefault.features_devel).toBe(true);
@@ -224,6 +225,7 @@ describe('Model', function() {
         expect(permissionsDefault.devices_input).toBe(false);
         expect(permissionsDefault.devices_kvm).toBe(false);
         expect(permissionsDefault.devices_shm).toBe(false);
+        expect(permissionsDefault.devices_usb).toBe(false);
         expect(permissionsDefault.devices_all).toBe(false);
         expect(permissionsDefault.features_bluetooth).toBe(false);
         expect(permissionsDefault.features_devel).toBe(false);
@@ -262,6 +264,7 @@ describe('Model', function() {
         expect(permissionsDefault.devices_input).toBe(false);
         expect(permissionsDefault.devices_kvm).toBe(false);
         expect(permissionsDefault.devices_shm).toBe(false);
+        expect(permissionsDefault.devices_usb).toBe(false);
         expect(permissionsDefault.devices_all).toBe(false);
         expect(permissionsDefault.features_bluetooth).toBe(false);
         expect(permissionsDefault.features_devel).toBe(false);
@@ -302,6 +305,7 @@ describe('Model', function() {
         expect(permissionsDefault.devices_input).toBe(true);
         expect(permissionsDefault.devices_kvm).toBe(true);
         expect(permissionsDefault.devices_shm).toBe(true);
+        expect(permissionsDefault.devices_usb).toBe(true);
         expect(permissionsDefault.devices_all).toBe(true);
         expect(permissionsDefault.features_bluetooth).toBe(true);
         expect(permissionsDefault.features_devel).toBe(true);
@@ -711,7 +715,7 @@ describe('Model', function() {
 
         const total = permissionsDefault.getAll().filter(p => p.supported).length;
 
-        expect(total).toEqual(_totalPermissions - 10);
+        expect(total).toEqual(_totalPermissions - 11);
     });
 
     it('handles missing .flatpak-info', function() {


### PR DESCRIPTION
Raw USB device access can be granted using `device=usb` as of flatpak version 1.15.11:
https://docs.flatpak.org/en/latest/sandbox-permissions.html#device-access