### PR TITLE
applications: Don't break if component not yet available

### DIFF
--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -277,6 +277,9 @@ var FlatpakApplicationsModel = GObject.registerClass({
         }
 
         const component = metadata.get_component();
+        if (component === null)
+            return desktop;
+
         const icon = component.get_icon_stock();
         if (icon === null)
             return desktop;
@@ -322,6 +325,8 @@ var FlatpakApplicationsModel = GObject.registerClass({
         }
 
         const component = metadata.get_component();
+        if (component === null)
+            return appdata;
 
         if (component.get_name())
             appdata.name = component.get_name();


### PR DESCRIPTION
I can only theorize about how this can happen, but I suspect it has something to do with some delayed export of the application appdata on the Flatpak side.

This will prevent Flatseal from breaking, at least.

Fixes #777