### PR TITLE
fix: Replace deprecated symbolic icon

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -36,7 +36,7 @@ row .content .path .info {
 row .content .relative.path .info,
 row .content .bus .info,
 row .content .variable .info {
-    background-image: -gtk-icontheme("emblem-ok-symbolic");
+    background-image: -gtk-icontheme("object-select-symbolic");
 }
 
 row .content .bus.not-valid .info,


### PR DESCRIPTION
Since GNOME 48, the `emblem-*-symbolic` icons have been [deprecated](https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/merge_requests/78/) and it is not backported to adwaita-icon-theme-legacy. This replaces it with a similar-looking checkmark icon so those that do not use an extensive custom icon theme (just base Adwaita) can see it.