### PR TITLE
dbus: Support Activatable with appId

### DIFF
--- a/data/com.github.tchx84.Flatseal.desktop.in
+++ b/data/com.github.tchx84.Flatseal.desktop.in
@@ -12,3 +12,4 @@ Icon=com.github.tchx84.Flatseal
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;
 Keywords=seal;sandbox;override;
+DBusActivatable=true

--- a/data/com.github.tchx84.Flatseal.service.in
+++ b/data/com.github.tchx84.Flatseal.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.github.tchx84.Flatseal
+Exec=@prefix@/@bindir@/com.github.tchx84.Flatseal --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -41,4 +41,15 @@ if compile_schemas.found()
   )
 endif
 
+conf = configuration_data()
+conf.set('prefix', get_option('prefix'))
+conf.set('bindir', get_option('bindir'))
+
+configure_file(
+  input: 'com.github.tchx84.Flatseal.service.in',
+  output: 'com.github.tchx84.Flatseal.service',
+  configuration: conf,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1', 'services')
+)
+
 subdir('icons')

--- a/src/application.js
+++ b/src/application.js
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const {GObject, Gtk, Gio, Adw} = imports.gi;
+const {GObject, Gtk, Gio, GLib, Adw} = imports.gi;
 
 const {FlatsealWindow} = imports.widgets.window;
 const {showAboutDialog} = imports.widgets.aboutDialog;
@@ -36,6 +36,7 @@ var FlatsealApplication = GObject.registerClass({
             resource_base_path: '/com/github/tchx84/Flatseal/',
         });
 
+        this._appId = null;
         this._window = null;
     }
 
@@ -100,9 +101,21 @@ var FlatsealApplication = GObject.registerClass({
         this.set_accels_for_action('window.close', ['<Control>w']);
     }
 
+    vfunc_before_emit(variant) {
+        const platform_data = variant.recursiveUnpack();
+
+        if (typeof platform_data.appId !== 'undefined')
+            this._appId = platform_data.appId;
+
+        super.vfunc_before_emit(variant);
+    }
+
     vfunc_activate() {
         if (this._window === null)
             this._window = new FlatsealWindow(this);
+
+        if (this._appId !== null)
+            this._window.activateApplication(this._appId);
 
         this._window.present();
     }

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -404,4 +404,10 @@ var FlatsealWindow = GObject.registerClass({
         this._shutdown();
         return super.vfunc_close_request();
     }
+
+    activateApplication(appId) {
+        const row = Array.from(this._applicationsListBox).find(row => row.appId === appId);
+        if (typeof row !== 'undefined')
+            this._activateApplication(this._applicationsListBox, row);
+    }
 });


### PR DESCRIPTION
This feature has been requested a few times now by the developers of projects like Warehouse, Bazaar, and others.

The following is an example of how to use this API:

```
gdbus call \
    --session \
    --dest com.github.tchx84.Flatseal \
    --object-path /com/github/tchx84/Flatseal \
    --method org.freedesktop.Application.Activate \
    "{'appId':<string 'org.gnome.Builder'>}"
```

Closes #782