### PR TITLE
dbus: Support activating Flatseal with a given appId

### DIFF
--- a/data/com.github.tchx84.Flatseal.desktop.in
+++ b/data/com.github.tchx84.Flatseal.desktop.in
@@ -12,3 +12,4 @@ Icon=com.github.tchx84.Flatseal
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;
 Keywords=seal;sandbox;override;
+DBusActivatable=true

--- a/data/com.github.tchx84.Flatseal.service.in
+++ b/data/com.github.tchx84.Flatseal.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.github.tchx84.Flatseal
+Exec=@prefix@/@bindir@/com.github.tchx84.Flatseal --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -41,4 +41,15 @@ if compile_schemas.found()
   )
 endif
 
+conf = configuration_data()
+conf.set('prefix', get_option('prefix'))
+conf.set('bindir', get_option('bindir'))
+
+configure_file(
+  input: 'com.github.tchx84.Flatseal.service.in',
+  output: 'com.github.tchx84.Flatseal.service',
+  configuration: conf,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1', 'services')
+)
+
 subdir('icons')

--- a/src/application.js
+++ b/src/application.js
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const {GObject, Gtk, Gio, Adw} = imports.gi;
+const {GObject, Gtk, Gio, GLib, Adw} = imports.gi;
 
 const {FlatsealWindow} = imports.widgets.window;
 const {showAboutDialog} = imports.widgets.aboutDialog;
@@ -72,6 +72,11 @@ var FlatsealApplication = GObject.registerClass({
         this.quit();
     }
 
+    _show(action, appId) {
+        this.activate();
+        this._window.showApplication(appId.unpack());
+    }
+
     _setupActions() {
         const help_action = new Gio.SimpleAction({name: 'help', state: null});
         help_action.connect('activate', this._displayHelp.bind(this));
@@ -88,11 +93,15 @@ var FlatsealApplication = GObject.registerClass({
         const quit_action = new Gio.SimpleAction({name: 'quit', state: null});
         quit_action.connect('activate', this._quit.bind(this));
 
+        const show_action = new Gio.SimpleAction({name: 'show', state: null, parameterType: GLib.VariantType.new('s')});
+        show_action.connect('activate', this._show.bind(this));
+
         this.add_action(help_action);
         this.add_action(documentation_action);
         this.add_action(shortcuts_action);
         this.add_action(about_action);
         this.add_action(quit_action);
+        this.add_action(show_action);
 
         this.set_accels_for_action('app.documentation', ['F1']);
         this.set_accels_for_action('app.shortcuts', ['<Control>question']);

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -404,4 +404,10 @@ var FlatsealWindow = GObject.registerClass({
         this._shutdown();
         return super.vfunc_close_request();
     }
+
+    showApplication(appId) {
+        const row = Array.from(this._applicationsListBox).find(r => r.appId === appId);
+        if (typeof row !== 'undefined')
+            this._activateApplication(this._applicationsListBox, row);
+    }
 });


### PR DESCRIPTION
This feature has been requested a few times now by the developers of projects like Warehouse, Bazaar, and others.

The following is an example of how to use this API:

```
gdbus call \
  --session \
  --dest com.github.tchx84.Flatseal \
  --object-path /com/github/tchx84/Flatseal \
  --method org.gtk.Actions.Activate \
  show "[<string 'org.gnome.Builder'>]" "{}"
```

Closes #782