### PR TITLE
chore(flatpak): add x-checker-data metadata for all modules

### DIFF
--- a/com.github.tchx84.Flatseal.json
+++ b/com.github.tchx84.Flatseal.json
@@ -36,7 +36,14 @@
                 {
                     "type": "git",
                     "url": "https://github.com/ptomato/jasmine-gjs.git",
-                    "commit": "856465dddbd92e82e574891e1ebc79e17d7b708a"
+                    "commit": "06d8ee3e291a0f25231669c67e4a961a8e836668",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/ptomato/jasmine-gjs/commits",
+                        "commit-query": "first( .[].sha )",
+                        "version-query": "first( .[].sha )",
+                        "timestamp-query": "first( .[].commit.committer.date )"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
This allows for automation tools like `x-checker-data` to update the modules automatically via PRs or other

I also added metadata for flatseal on flathub on this PR: https://github.com/flathub/com.github.tchx84.Flatseal/pull/64

<img width="1701" height="693" alt="image" src="https://github.com/user-attachments/assets/ae8255d5-4189-4cea-a699-0e185577a51e" />
