### PR TITLE
fix: Handle malformed custom installation config files gracefully

### DIFF
--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -122,7 +122,13 @@ var FlatpakApplicationsModel = GObject.registerClass({
         const installations = [];
 
         const keyFile = new GLib.KeyFile();
-        keyFile.load_from_file(path, GLib.KeyFileFlags.NONE);
+
+        try {
+            keyFile.load_from_file(path, GLib.KeyFileFlags.NONE);
+        } catch (err) {
+            logError(err, `Could not load custom installation from ${path}`);
+            return installations;
+        }
 
         const [groups] = keyFile.get_groups();
         groups.forEach(group => {

--- a/src/models/portals.js
+++ b/src/models/portals.js
@@ -260,7 +260,7 @@ var FlatpakPortalsModel = GObject.registerClass({
 
         this._setup();
 
-        if (this._proxy === null || this._proxy.version >= SUPPORTED_SERVICE_VERSION === false) {
+        if (this._proxy === null || this._proxy.version < SUPPORTED_SERVICE_VERSION) {
             this[`_${table}${id}Reason`] = _('Requires permission store version 2 or newer');
             this[`_${table}${id}Supported`] = false;
             return false;


### PR DESCRIPTION
_parseCustomInstallation() did not wrap keyFile.load_from_file() in a
try-catch block. If /etc/flatpak/installations.d/ contained a malformed,
binary, or otherwise unreadable .conf file, Flatseal would crash entirely
instead of skipping the bad file.

Also simplify the version check in portals.js for readability:
  Before: this._proxy.version >= SUPPORTED_SERVICE_VERSION === false
  After:  this._proxy.version < SUPPORTED_SERVICE_VERSION
(functionally equivalent, but clearer)