### PR TITLE
Feat/modified permissions indicator

### DIFF
--- a/src/com.github.tchx84.Flatseal.src.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.src.gresource.xml
@@ -25,6 +25,7 @@
     <file>models/globalModel.js</file>
     <file>models/info.js</file>
     <file>models/overrideStatus.js</file>
+    <file>models/overrides.js</file>
     <file>models/unsupported.js</file>
     <file>models/persistent.js</file>
     <file>models/permissions.js</file>

--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -389,12 +389,12 @@ var FlatpakApplicationsModel = GObject.registerClass({
         return GLib.build_filenamev([this._getBundlePathForAppId(appId), 'metadata']);
     }
 
-    getOverridesPaths() {
-        return this._getInstallationsPaths().map(path => GLib.build_filenamev([path, 'overrides']));
-    }
-
     get userPath() {
         return this._getUserPath();
+    }
+
+    get userOverridesPath() {
+        return GLib.build_filenamev([this._getUserPath(), 'overrides']);
     }
 
     shutdown() {

--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -389,6 +389,10 @@ var FlatpakApplicationsModel = GObject.registerClass({
         return GLib.build_filenamev([this._getBundlePathForAppId(appId), 'metadata']);
     }
 
+    getOverridesPaths() {
+        return this._getInstallationsPaths().map(path => GLib.build_filenamev([path, 'overrides']));
+    }
+
     get userPath() {
         return this._getUserPath();
     }

--- a/src/models/overrides.js
+++ b/src/models/overrides.js
@@ -1,0 +1,110 @@
+/* overrides.js
+ *
+ * Copyright 2026 Kafilat Adeleke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const {GLib, Gio, GObject} = imports.gi;
+
+const SIGNAL_DELAY = 500;
+
+var FlatpakOverridesModel = GObject.registerClass({
+    GTypeName: 'FlatpakOverridesModel',
+    Signals: {
+        'changed': {},
+    },
+}, class FlatpakOverridesModel extends GObject.Object {
+    _init(paths) {
+        super._init();
+        this._overriddenApps = new Set();
+        this._monitors = [];
+        this._changedDelayHandlerId = 0;
+        this._setup(paths);
+    }
+
+    _setup(paths) {
+        paths.forEach(path => {
+            const directory = Gio.File.new_for_path(path);
+
+            /* Scan existing files */
+            if (GLib.access(path, 0) === 0) {
+                try {
+                    const enumerator = directory.enumerate_children(
+                        'standard::name',
+                        Gio.FileQueryInfoFlags.NONE,
+                        null
+                    );
+                    let fileInfo = enumerator.next_file(null);
+                    while (fileInfo !== null) {
+                        this._overriddenApps.add(fileInfo.get_name());
+                        fileInfo = enumerator.next_file(null);
+                    }
+                } catch (e) {
+                    /* Directory may be empty or inaccessible */
+                }
+            }
+
+            /* Watch for future changes */
+            try {
+                const monitor = directory.monitor_directory(
+                    Gio.FileMonitorFlags.NONE,
+                    null
+                );
+                monitor.connect('changed', this._onDirectoryChanged.bind(this));
+                this._monitors.push(monitor);
+            } catch (e) {
+                /* Directory doesn't exist yet, skip monitoring */
+            }
+        });
+    }
+
+    _onDirectoryChanged(monitor, file, _otherFile, eventType) {
+        const name = file.get_basename();
+
+        if (eventType === Gio.FileMonitorEvent.CREATED ||
+            eventType === Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
+            this._overriddenApps.add(name);
+            this._emitChangedDelayed();
+        } else if (eventType === Gio.FileMonitorEvent.DELETED) {
+            this._overriddenApps.delete(name);
+            this._emitChangedDelayed();
+        }
+    }
+
+    _emitChangedDelayed() {
+        if (this._changedDelayHandlerId !== 0)
+            GLib.Source.remove(this._changedDelayHandlerId);
+
+        this._changedDelayHandlerId = GLib.timeout_add(
+            GLib.PRIORITY_DEFAULT, SIGNAL_DELAY, () => {
+                this.emit('changed');
+                this._changedDelayHandlerId = 0;
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    isOverridden(appId) {
+        return this._overriddenApps.has(appId);
+    }
+
+    shutdown() {
+        if (this._changedDelayHandlerId !== 0)
+            GLib.Source.remove(this._changedDelayHandlerId);
+        this._changedDelayHandlerId = 0;
+
+        this._monitors.forEach(m => m.cancel());
+        this._monitors = [];
+    }
+});

--- a/src/models/overrides.js
+++ b/src/models/overrides.js
@@ -108,13 +108,3 @@ var FlatpakOverridesModel = GObject.registerClass({
         this._monitors = [];
     }
 });
-
-
-var getDefault = (function() {
-    let instance;
-    return function(paths) {
-        if (typeof instance === 'undefined')
-            instance = new FlatpakOverridesModel(paths);
-        return instance;
-    };
-}());

--- a/src/models/overrides.js
+++ b/src/models/overrides.js
@@ -108,3 +108,13 @@ var FlatpakOverridesModel = GObject.registerClass({
         this._monitors = [];
     }
 });
+
+
+var getDefault = (function() {
+    let instance;
+    return function(paths) {
+        if (typeof instance === 'undefined')
+            instance = new FlatpakOverridesModel(paths);
+        return instance;
+    };
+}());

--- a/src/models/overrides.js
+++ b/src/models/overrides.js
@@ -75,6 +75,8 @@ var FlatpakOverridesModel = GObject.registerClass({
 
         if (eventType === Gio.FileMonitorEvent.CREATED ||
             eventType === Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
+            if (this._overriddenApps.has(name))
+                return;
             this._overriddenApps.add(name);
             this._emitChangedDelayed();
         } else if (eventType === Gio.FileMonitorEvent.DELETED) {

--- a/src/models/overrides.js
+++ b/src/models/overrides.js
@@ -26,48 +26,45 @@ var FlatpakOverridesModel = GObject.registerClass({
         'changed': {},
     },
 }, class FlatpakOverridesModel extends GObject.Object {
-    _init(paths) {
+    _init(path) {
         super._init();
         this._overriddenApps = new Set();
-        this._monitors = [];
+        this._monitor = null;
         this._changedDelayHandlerId = 0;
-        this._setup(paths);
+        this._setup(path);
     }
 
-    _setup(paths) {
-        paths.forEach(path => {
-            const directory = Gio.File.new_for_path(path);
+    _setup(path) {
+        const directory = Gio.File.new_for_path(path);
 
-            /* Scan existing files */
-            if (GLib.access(path, 0) === 0) {
-                try {
-                    const enumerator = directory.enumerate_children(
-                        'standard::name',
-                        Gio.FileQueryInfoFlags.NONE,
-                        null
-                    );
-                    let fileInfo = enumerator.next_file(null);
-                    while (fileInfo !== null) {
-                        this._overriddenApps.add(fileInfo.get_name());
-                        fileInfo = enumerator.next_file(null);
-                    }
-                } catch (e) {
-                    /* Directory may be empty or inaccessible */
-                }
-            }
-
-            /* Watch for future changes */
+        /* Scan existing files */
+        if (GLib.access(path, 0) === 0) {
             try {
-                const monitor = directory.monitor_directory(
-                    Gio.FileMonitorFlags.NONE,
+                const enumerator = directory.enumerate_children(
+                    'standard::name',
+                    Gio.FileQueryInfoFlags.NONE,
                     null
                 );
-                monitor.connect('changed', this._onDirectoryChanged.bind(this));
-                this._monitors.push(monitor);
+                let fileInfo = enumerator.next_file(null);
+                while (fileInfo !== null) {
+                    this._overriddenApps.add(fileInfo.get_name());
+                    fileInfo = enumerator.next_file(null);
+                }
             } catch (e) {
-                /* Directory doesn't exist yet, skip monitoring */
+                /* Directory may be empty or inaccessible */
             }
-        });
+        }
+
+        /* Watch for future changes */
+        try {
+            this._monitor = directory.monitor_directory(
+                Gio.FileMonitorFlags.NONE,
+                null
+            );
+            this._monitor.connect('changed', this._onDirectoryChanged.bind(this));
+        } catch (e) {
+            /* Directory doesn't exist yet, skip monitoring */
+        }
     }
 
     _onDirectoryChanged(monitor, file, _otherFile, eventType) {
@@ -106,7 +103,9 @@ var FlatpakOverridesModel = GObject.registerClass({
             GLib.Source.remove(this._changedDelayHandlerId);
         this._changedDelayHandlerId = 0;
 
-        this._monitors.forEach(m => m.cancel());
-        this._monitors = [];
+        if (this._monitor) {
+            this._monitor.cancel();
+            this._monitor = null;
+        }
     }
 });

--- a/src/models/portals.js
+++ b/src/models/portals.js
@@ -384,20 +384,6 @@ var FlatpakPortalsModel = GObject.registerClass({
         return false;
     }
 
-    getAppsWithPortalChanges() {
-        const apps = new Set();
-        for (const [, permission] of Object.entries(this.getPermissions())) {
-            if (!this.isSupported(permission.table, permission.id))
-                continue;
-
-            const [appIds] = this.safeLookUp(permission.table, permission.id);
-            if (appIds !== null)
-                Object.keys(appIds).forEach(appId => apps.add(appId));
-        }
-
-        return apps;
-    }
-
     saveToKeyFile() {
 
         /* this backend has no file */

--- a/src/models/portals.js
+++ b/src/models/portals.js
@@ -384,7 +384,7 @@ var FlatpakPortalsModel = GObject.registerClass({
         return false;
     }
 
-    getAppsWithChanges() {
+    getAppsWithPortalChanges() {
         const apps = new Set();
         for (const [, permission] of Object.entries(this.getPermissions())) {
             if (!this.isSupported(permission.table, permission.id))

--- a/src/models/portals.js
+++ b/src/models/portals.js
@@ -384,6 +384,20 @@ var FlatpakPortalsModel = GObject.registerClass({
         return false;
     }
 
+    getAppsWithChanges() {
+        const apps = new Set();
+        for (const [, permission] of Object.entries(this.getPermissions())) {
+            if (!this.isSupported(permission.table, permission.id))
+                continue;
+
+            const [appIds] = this.safeLookUp(permission.table, permission.id);
+            if (appIds !== null)
+                Object.keys(appIds).forEach(appId => apps.add(appId));
+        }
+
+        return apps;
+    }
+
     saveToKeyFile() {
 
         /* this backend has no file */

--- a/src/style.css
+++ b/src/style.css
@@ -8,11 +8,6 @@
 
 row .status {
     padding: 8px;
-    background-color: transparent;
-    background-image: -gtk-icontheme("dialog-warning-symbolic");
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: 16px;
 }
 row .status.user {
     color: @accent_color;

--- a/src/widgets/applicationRow.js
+++ b/src/widgets/applicationRow.js
@@ -24,13 +24,21 @@ const {GLib, GObject, Adw} = imports.gi;
 var FlatsealApplicationRow = GObject.registerClass({
     GTypeName: 'FlatsealApplicationRow',
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/applicationRow.ui',
-    InternalChildren: ['icon'],
+    InternalChildren: ['icon', 'status'],
 }, class FlatsealApplicationRow extends Adw.ActionRow {
     _init(appId, appName, appIconName) {
         super._init();
         this._icon.set_from_icon_name(appIconName);
         this.set_title(GLib.markup_escape_text(appName, -1));
         this.set_subtitle(appId);
+    }
+
+    set changed(changed) {
+        this._status.visible = changed;
+    }
+
+    get changed() {
+        return this._status.visible;
     }
 
     get appId() {

--- a/src/widgets/applicationRow.ui
+++ b/src/widgets/applicationRow.ui
@@ -16,6 +16,17 @@
         </style>
       </object>
     </child>
+    <child>
+      <object class="GtkImage" id="status">
+        <property name="valign">center</property>
+        <property name="visible">False</property>
+        <property name="tooltip-text" translatable="yes">Changed by the user</property>
+        <style>
+          <class name="status"/>
+          <class name="user"/>
+        </style>
+      </object>
+    </child>
     <style>
       <class name="row"/>
     </style>

--- a/src/widgets/applicationRow.ui
+++ b/src/widgets/applicationRow.ui
@@ -20,6 +20,7 @@
       <object class="GtkImage" id="status">
         <property name="valign">center</property>
         <property name="visible">False</property>
+        <property name="icon-name">media-record-symbolic</property>
         <property name="tooltip-text" translatable="yes">Changed by the user</property>
         <style>
           <class name="status"/>

--- a/src/widgets/globalRow.js
+++ b/src/widgets/globalRow.js
@@ -24,10 +24,18 @@ const {GObject, Adw} = imports.gi;
 var FlatsealGlobalRow = GObject.registerClass({
     GTypeName: 'FlatsealGlobalRow',
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/globalRow.ui',
-    InternalChildren: ['icon'],
+    InternalChildren: ['icon', 'status'],
 }, class FlatsealGlobalRow extends Adw.ActionRow {
     _init() {
         super._init();
+    }
+
+    set changed(changed) {
+        this._status.visible = changed;
+    }
+
+    get changed() {
+        return this._status.visible;
     }
 
     get appId() {

--- a/src/widgets/globalRow.ui
+++ b/src/widgets/globalRow.ui
@@ -18,6 +18,17 @@
         </style>
       </object>
     </child>
+    <child>
+      <object class="GtkImage" id="status">
+        <property name="valign">center</property>
+        <property name="visible">False</property>
+        <property name="tooltip-text" translatable="yes">Changed by the user</property>
+        <style>
+          <class name="status"/>
+          <class name="user"/>
+        </style>
+      </object>
+    </child>
     <style>
       <class name="row"/>
     </style>

--- a/src/widgets/globalRow.ui
+++ b/src/widgets/globalRow.ui
@@ -22,6 +22,7 @@
       <object class="GtkImage" id="status">
         <property name="valign">center</property>
         <property name="visible">False</property>
+        <property name="icon-name">media-record-symbolic</property>
         <property name="tooltip-text" translatable="yes">Changed by the user</property>
         <style>
           <class name="status"/>

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -93,6 +93,8 @@ var FlatsealWindow = GObject.registerClass({
             });
         });
 
+        this.connect('destroy', () => this._overrides.shutdown());
+
         this._detailsHeaderButton = new FlatsealDetailsButton(this._permissions);
         this._startHeaderBox.append(this._detailsHeaderButton);
         this._resetHeaderButton = new FlatsealResetButton(this._permissions);
@@ -289,6 +291,7 @@ var FlatsealWindow = GObject.registerClass({
     }
 
     _shutdown() {
+        this._overrides.shutdown();
         this._permissions.shutdown();
         this._applications.shutdown();
     }

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -93,7 +93,7 @@ var FlatsealWindow = GObject.registerClass({
             });
         });
 
-        this.connect('destroy', () => this._overrides.shutdown());
+
 
         this._detailsHeaderButton = new FlatsealDetailsButton(this._permissions);
         this._startHeaderBox.append(this._detailsHeaderButton);

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -84,7 +84,7 @@ var FlatsealWindow = GObject.registerClass({
         this._permissions = permissions.getDefault();
         this._applications = applications.getDefault();
 
-        this._overrides = overrides.getDefault(
+        this._overrides = new overrides.FlatpakOverridesModel(
             this._applications.getOverridesPaths());
         this._overrides.connect('changed', () => {
             this._applicationsListBox.foreach(row => {

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -93,8 +93,6 @@ var FlatsealWindow = GObject.registerClass({
             });
         });
 
-
-
         this._detailsHeaderButton = new FlatsealDetailsButton(this._permissions);
         this._startHeaderBox.append(this._detailsHeaderButton);
         this._resetHeaderButton = new FlatsealResetButton(this._permissions);

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -87,10 +87,10 @@ var FlatsealWindow = GObject.registerClass({
         this._overrides = new overrides.FlatpakOverridesModel(
             this._applications.userOverridesPath);
         this._overrides.connect('changed', () => {
-            this._applicationsListBox.foreach(row => {
+            for (const row of Array.from(this._applicationsListBox)) {
                 if (row instanceof FlatsealApplicationRow || row instanceof FlatsealGlobalRow)
                     row.changed = this._overrides.isOverridden(row.appId);
-            });
+            }
         });
 
         this._detailsHeaderButton = new FlatsealDetailsButton(this._permissions);

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const {GObject, Gtk, Adw} = imports.gi;
+const {GLib, Gio, GObject, Gtk, Adw} = imports.gi;
 
-const {applications, permissions} = imports.models;
+const {applications, permissions, portals} = imports.models;
 
 const {FlatsealAppInfoViewer} = imports.widgets.appInfoViewer;
 const {FlatsealGlobalInfoViewer} = imports.widgets.globalInfoViewer;
@@ -121,6 +121,11 @@ var FlatsealWindow = GObject.registerClass({
         this._applicationsListBox.set_sort_func(this._sort.bind(this));
         this._applicationsListBox.connect('row-activated', this._activateApplication.bind(this));
 
+        this._permissions.connect('changed', (model, overriden) => {
+            if (this._activatedRow)
+                this._activatedRow.changed = overriden;
+        });
+
         this._applicationsSearchEntry.connect('activate', this._selectSearch.bind(this));
         this._applicationsSearchEntry.connect('search-changed', this._resetSearch.bind(this));
 
@@ -155,12 +160,28 @@ var FlatsealWindow = GObject.registerClass({
         this._contentLeaflet.show_content = true;
         this._permissionsStack.visibleChildName = 'withPermissionsPage';
 
+        /* Cache changed applications */
+        const changedApps = portals.getDefault().getAppsWithChanges();
+        const overridesPath = GLib.build_filenamev([this._applications.userPath, 'overrides']);
+
+        if (GLib.access(overridesPath, 0) === 0) {
+            const directory = Gio.File.new_for_path(overridesPath);
+            const enumerator = directory.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, null);
+            let fileInfo = enumerator.next_file(null);
+
+            while (fileInfo !== null) {
+                changedApps.add(fileInfo.get_name());
+                fileInfo = enumerator.next_file(null);
+            }
+        }
+
         /* Add rows for every application */
         const iconTheme = Gtk.IconTheme.get_for_display(this.get_display());
 
         allApplications.forEach(app => {
             iconTheme.add_search_path(app.appThemePath);
             const row = new FlatsealApplicationRow(app.appId, app.appName, app.appIconName);
+            row.changed = changedApps.has(app.appId);
             this._applicationsListBox.append(row);
 
             if (app.appId === this._settings.getSelectedAppId())
@@ -169,6 +190,7 @@ var FlatsealWindow = GObject.registerClass({
 
         /* Add row for global overrides */
         this._globalRow = new FlatsealGlobalRow();
+        this._globalRow.changed = changedApps.has('global');
         this._applicationsListBox.append(this._globalRow);
 
         /* Select after the list has been sorted */

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -20,7 +20,7 @@
 
 const {GLib, Gio, GObject, Gtk, Adw} = imports.gi;
 
-const {applications, permissions, portals} = imports.models;
+const {applications, permissions, overrides} = imports.models;
 
 const {FlatsealAppInfoViewer} = imports.widgets.appInfoViewer;
 const {FlatsealGlobalInfoViewer} = imports.widgets.globalInfoViewer;
@@ -84,6 +84,15 @@ var FlatsealWindow = GObject.registerClass({
         this._permissions = permissions.getDefault();
         this._applications = applications.getDefault();
 
+        this._overrides = new overrides.FlatpakOverridesModel(
+            this._applications.getOverridesPaths());
+        this._overrides.connect('changed', () => {
+            this._applicationsListBox.foreach(row => {
+                if (row instanceof FlatsealApplicationRow || row instanceof FlatsealGlobalRow)
+                    row.changed = this._overrides.isOverridden(row.appId);
+            });
+        });
+
         this._detailsHeaderButton = new FlatsealDetailsButton(this._permissions);
         this._startHeaderBox.append(this._detailsHeaderButton);
         this._resetHeaderButton = new FlatsealResetButton(this._permissions);
@@ -121,11 +130,6 @@ var FlatsealWindow = GObject.registerClass({
         this._applicationsListBox.set_sort_func(this._sort.bind(this));
         this._applicationsListBox.connect('row-activated', this._activateApplication.bind(this));
 
-        this._permissions.connect('changed', (model, overriden) => {
-            if (this._activatedRow)
-                this._activatedRow.changed = overriden;
-        });
-
         this._applicationsSearchEntry.connect('activate', this._selectSearch.bind(this));
         this._applicationsSearchEntry.connect('search-changed', this._resetSearch.bind(this));
 
@@ -160,30 +164,13 @@ var FlatsealWindow = GObject.registerClass({
         this._contentLeaflet.show_content = true;
         this._permissionsStack.visibleChildName = 'withPermissionsPage';
 
-        /* Cache changed applications */
-        const changedApps = portals.getDefault().getAppsWithPortalChanges();
-        const overridesPaths = this._applications.getOverridesPaths();
-
-        overridesPaths.forEach(overridesPath => {
-            if (GLib.access(overridesPath, 0) === 0) {
-                const directory = Gio.File.new_for_path(overridesPath);
-                const enumerator = directory.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, null);
-                let fileInfo = enumerator.next_file(null);
-
-                while (fileInfo !== null) {
-                    changedApps.add(fileInfo.get_name());
-                    fileInfo = enumerator.next_file(null);
-                }
-            }
-        });
-
         /* Add rows for every application */
         const iconTheme = Gtk.IconTheme.get_for_display(this.get_display());
 
         allApplications.forEach(app => {
             iconTheme.add_search_path(app.appThemePath);
             const row = new FlatsealApplicationRow(app.appId, app.appName, app.appIconName);
-            row.changed = changedApps.has(app.appId);
+            row.changed = this._overrides.isOverridden(app.appId);
             this._applicationsListBox.append(row);
 
             if (app.appId === this._settings.getSelectedAppId())
@@ -192,7 +179,7 @@ var FlatsealWindow = GObject.registerClass({
 
         /* Add row for global overrides */
         this._globalRow = new FlatsealGlobalRow();
-        this._globalRow.changed = changedApps.has('global');
+        this._globalRow.changed = this._overrides.isOverridden('global');
         this._applicationsListBox.append(this._globalRow);
 
         /* Select after the list has been sorted */

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -84,7 +84,7 @@ var FlatsealWindow = GObject.registerClass({
         this._permissions = permissions.getDefault();
         this._applications = applications.getDefault();
 
-        this._overrides = new overrides.FlatpakOverridesModel(
+        this._overrides = overrides.getDefault(
             this._applications.getOverridesPaths());
         this._overrides.connect('changed', () => {
             this._applicationsListBox.foreach(row => {

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const {GLib, Gio, GObject, Gtk, Adw} = imports.gi;
+const {GObject, Gtk, Adw} = imports.gi;
 
 const {applications, permissions, overrides} = imports.models;
 

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -161,19 +161,21 @@ var FlatsealWindow = GObject.registerClass({
         this._permissionsStack.visibleChildName = 'withPermissionsPage';
 
         /* Cache changed applications */
-        const changedApps = portals.getDefault().getAppsWithChanges();
-        const overridesPath = GLib.build_filenamev([this._applications.userPath, 'overrides']);
+        const changedApps = portals.getDefault().getAppsWithPortalChanges();
+        const overridesPaths = this._applications.getOverridesPaths();
 
-        if (GLib.access(overridesPath, 0) === 0) {
-            const directory = Gio.File.new_for_path(overridesPath);
-            const enumerator = directory.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, null);
-            let fileInfo = enumerator.next_file(null);
+        overridesPaths.forEach(overridesPath => {
+            if (GLib.access(overridesPath, 0) === 0) {
+                const directory = Gio.File.new_for_path(overridesPath);
+                const enumerator = directory.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, null);
+                let fileInfo = enumerator.next_file(null);
 
-            while (fileInfo !== null) {
-                changedApps.add(fileInfo.get_name());
-                fileInfo = enumerator.next_file(null);
+                while (fileInfo !== null) {
+                    changedApps.add(fileInfo.get_name());
+                    fileInfo = enumerator.next_file(null);
+                }
             }
-        }
+        });
 
         /* Add rows for every application */
         const iconTheme = Gtk.IconTheme.get_for_display(this.get_display());

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -85,7 +85,7 @@ var FlatsealWindow = GObject.registerClass({
         this._applications = applications.getDefault();
 
         this._overrides = new overrides.FlatpakOverridesModel(
-            this._applications.getOverridesPaths());
+            this._applications.userOverridesPath);
         this._overrides.connect('changed', () => {
             this._applicationsListBox.foreach(row => {
                 if (row instanceof FlatsealApplicationRow || row instanceof FlatsealGlobalRow)

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1465,16 +1465,13 @@ describe('Model', function() {
     it('identifies applications with modified overrides', function() {
         GLib.setenv('FLATPAK_USER_DIR', _user, true);
 
-        const paths = applicationsDefault.getOverridesPaths();
-        paths.push(_overrides);
-
-        const model = new overridesDefault.FlatpakOverridesModel(paths);
+        const model = new overridesDefault.FlatpakOverridesModel(applicationsDefault.userOverridesPath);
 
         expect(model.isOverridden(_basicAppId)).toBe(true);
         expect(model.isOverridden('some-non-existent-app')).toBe(false);
 
         /* Test reactive change */
-        const tempOverride = GLib.build_filenamev([_overrides, 'com.test.Reactive']);
+        const tempOverride = GLib.build_filenamev([applicationsDefault.userOverridesPath, 'com.test.Reactive']);
         GLib.file_set_contents(tempOverride, '[Context]\nshared=network;');
 
         update();

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1465,8 +1465,10 @@ describe('Model', function() {
     it('identifies applications with modified overrides', function() {
         GLib.setenv('FLATPAK_USER_DIR', _user, true);
 
-        const model = overridesDefault.getDefault(
-            applicationsDefault.getOverridesPaths());
+        const paths = applicationsDefault.getOverridesPaths();
+        paths.push(_overrides);
+
+        const model = new overridesDefault.FlatpakOverridesModel(paths);
 
         expect(model.isOverridden(_basicAppId)).toBe(true);
         expect(model.isOverridden('some-non-existent-app')).toBe(false);

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -91,18 +91,19 @@ const _flatpakConfig = GLib.build_filenamev(['..', 'tests', 'content']);
 
 
 describe('Model', function() {
-    var delay, permissionsDefault, applicationsDefault, infoDefault, portalsDefault, portalState;
+    var delay, permissionsDefault, applicationsDefault, infoDefault, portalsDefault, overridesDefault, portalState;
 
     beforeAll(function() {
         startService();
         waitForService();
 
-        const {applications, info, permissions, portals} = imports.models;
+        const {applications, info, permissions, portals, overrides} = imports.models;
 
         infoDefault = info.getDefault();
         portalsDefault = portals.getDefault();
         applicationsDefault = applications.getDefault();
         permissionsDefault = permissions.getDefault();
+        overridesDefault = overrides;
 
         delay = permissions.DELAY;
         portalState = portals.FlatpakPortalState;
@@ -1461,19 +1462,27 @@ describe('Model', function() {
         expect(permissionsDefault.emit.calls.first().args).toEqual(['failed']);
     });
 
-    it('identifies applications with portal changes', function() {
-        portalsDefault.appId = _basicAppId;
-        expect(portalsDefault.getAppsWithPortalChanges().has(_basicAppId)).toBe(false);
+    it('identifies applications with modified overrides', function() {
+        GLib.setenv('FLATPAK_USER_DIR', _user, true);
 
-        permissionsDefault.appId = _basicAppId;
-        permissionsDefault.set_property('portals-background', portalState.ALLOWED);
+        const model = new overridesDefault.FlatpakOverridesModel(
+            applicationsDefault.getOverridesPaths());
+
+        expect(model.isOverridden(_basicAppId)).toBe(true);
+        expect(model.isOverridden('some-non-existent-app')).toBe(false);
+
+        /* Test reactive change */
+        const tempOverride = GLib.build_filenamev([_overrides, 'com.test.Reactive']);
+        GLib.file_set_contents(tempOverride, '[Context]\nshared=network;');
+
         update();
+        /* monitor might need a bit of time, but update() usually flushes events in tests */
+        expect(model.isOverridden('com.test.Reactive')).toBe(true);
 
-        expect(portalsDefault.getAppsWithPortalChanges().has(_basicAppId)).toBe(true);
-        expect(portalsDefault.getAppsWithPortalChanges().has('some-other-app')).toBe(false);
-
-        permissionsDefault.set_property('portals-background', portalState.UNSET);
+        GLib.unlink(tempOverride);
         update();
-        expect(portalsDefault.getAppsWithPortalChanges().has(_basicAppId)).toBe(false);
+        expect(model.isOverridden('com.test.Reactive')).toBe(false);
+
+        model.shutdown();
     });
 });

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1465,7 +1465,7 @@ describe('Model', function() {
     it('identifies applications with modified overrides', function() {
         GLib.setenv('FLATPAK_USER_DIR', _user, true);
 
-        const model = new overridesDefault.FlatpakOverridesModel(
+        const model = overridesDefault.getDefault(
             applicationsDefault.getOverridesPaths());
 
         expect(model.isOverridden(_basicAppId)).toBe(true);

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1460,4 +1460,20 @@ describe('Model', function() {
 
         expect(permissionsDefault.emit.calls.first().args).toEqual(['failed']);
     });
+
+    it('identifies applications with portal changes', function() {
+        portalsDefault.appId = _basicAppId;
+        expect(portalsDefault.getAppsWithPortalChanges().has(_basicAppId)).toBe(false);
+
+        permissionsDefault.appId = _basicAppId;
+        permissionsDefault.set_property('portals-background', portalState.ALLOWED);
+        update();
+
+        expect(portalsDefault.getAppsWithPortalChanges().has(_basicAppId)).toBe(true);
+        expect(portalsDefault.getAppsWithPortalChanges().has('some-other-app')).toBe(false);
+
+        permissionsDefault.set_property('portals-background', portalState.UNSET);
+        update();
+        expect(portalsDefault.getAppsWithPortalChanges().has(_basicAppId)).toBe(false);
+    });
 });


### PR DESCRIPTION
Closes #837
Adds a visual indicator in the application list for apps with user-modified permissions. The badge appears on both individual app rows and the global row. Detection combines portal-level changes and file-based overrides across all override paths.