### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/com.github.tchx84.Flatseal.json
+++ b/com.github.tchx84.Flatseal.json
@@ -16,17 +16,6 @@
         "--talk-name=org.gnome.Software",
         "--talk-name=org.freedesktop.impl.portal.PermissionStore"
     ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules": [
         {
             "name": "jasmine-gjs",


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.