### PR TITLE
po: Add Vietnamese translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -24,3 +24,4 @@ fr
 zh_CN
 ta
 uk
+vi

--- a/po/vi.po
+++ b/po/vi.po
@@ -1,0 +1,615 @@
+# Vietnamese translations for flatseal package.
+# Copyright (C) 2021 THE flatseal'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the flatseal package.
+# 
+msgid ""
+msgstr ""
+"Project-Id-Version: flatseal\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-12 13:59-0300\n"
+"PO-Revision-Date: 2026-05-02 00:00+0700\n"
+"Last-Translator: \n"
+"Language-Team: Vietnamese\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. TRANSLATORS: Don't translate this text
+#: data/com.github.tchx84.Flatseal.desktop.in:3
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:4
+msgid "Flatseal"
+msgstr ""
+
+#: data/com.github.tchx84.Flatseal.desktop.in:9
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:10
+msgid "Manage Flatpak permissions"
+msgstr "Quản lý quyền Flatpak"
+
+#: data/com.github.tchx84.Flatseal.desktop.in:14
+msgid "seal;sandbox;override;"
+msgstr "seal;sandbox;override;"
+
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:12
+msgid ""
+"Flatseal is a graphical utility to review and modify permissions from your "
+"Flatpak applications."
+msgstr ""
+"Flatseal là tiện ích đồ họa để xem xét và sửa đổi quyền từ các ứng dụng "
+"Flatpak của bạn."
+
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:21
+msgid "The Flatseal main window"
+msgstr "Cửa sổ chính của Flatseal"
+
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:25
+msgid "Flatseal showing filesystem permissions"
+msgstr "Flatseal hiển thị quyền hệ thống tệp"
+
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:29
+msgid "Flatseal showing global overrides"
+msgstr "Flatseal hiển thị ghi đè toàn cục"
+
+#. TRANSLATORS: Don't translate this text
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:35
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:37
+msgid "Martin Abente Lahaye"
+msgstr ""
+
+#: data/com.github.tchx84.Flatseal.gschema.xml:15
+msgid "Application ID that was last selected"
+msgstr "ID ứng dụng được chọn lần cuối"
+
+#: src/models/applications.js:237 src/models/applications.js:298
+#: src/models/applications.js:299 src/models/applications.js:300
+#: src/widgets/globalInfoViewer.ui:105 src/widgets/globalInfoViewer.ui:119
+#: src/widgets/globalInfoViewer.ui:133
+msgid "Unknown"
+msgstr "Không xác định"
+
+#: src/models/sessionBus.js:38 src/models/systemBus.js:37
+msgid "Talks"
+msgstr "Giao tiếp"
+
+#: src/models/sessionBus.js:45 src/models/systemBus.js:44
+msgid "Owns"
+msgstr "Sở hữu"
+
+#: src/models/sessionBus.js:82
+msgid "List of well-known names on the session bus"
+msgstr "Danh sách tên nổi tiếng trên bus phiên"
+
+#: src/models/systemBus.js:73
+msgid "List of well-known names on the system bus"
+msgstr "Danh sách tên nổi tiếng trên bus hệ thống"
+
+#: src/models/devices.js:37
+msgid "GPU acceleration"
+msgstr "Tăng tốc GPU"
+
+#: src/models/devices.js:44
+msgid "Input devices"
+msgstr "Thiết bị đầu vào"
+
+#: src/models/devices.js:51
+msgid "Virtualization"
+msgstr "Ảo hóa"
+
+#: src/models/devices.js:58
+msgid "Shared memory"
+msgstr "Bộ nhớ chia sẻ"
+
+#: src/models/devices.js:65
+msgid "USB devices"
+msgstr "Thiết bị USB"
+
+#: src/models/devices.js:72
+msgid "All devices (e.g. webcam)"
+msgstr "Tất cả thiết bị (ví dụ: webcam)"
+
+#: src/models/devices.js:97
+msgid "List of devices available in the sandbox"
+msgstr "Danh sách thiết bị có sẵn trong môi trường sandbox"
+
+#: src/models/features.js:37
+msgid "Development syscalls (e.g. ptrace)"
+msgstr "Lời gọi hệ thống phát triển (ví dụ: ptrace)"
+
+#: src/models/features.js:44
+msgid "Programs from other architectures"
+msgstr "Chương trình từ các kiến trúc khác"
+
+#: src/models/features.js:51
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: src/models/features.js:58
+msgid "Controller Area Network bus"
+msgstr "Bus mạng CAN"
+
+#: src/models/features.js:65
+msgid "Application Shared Memory"
+msgstr "Bộ nhớ chia sẻ ứng dụng"
+
+#: src/models/features.js:90
+msgid "List of features available to the application"
+msgstr "Danh sách tính năng có sẵn cho ứng dụng"
+
+#: src/models/filesystems.js:37
+msgid "All system files"
+msgstr "Tất cả tệp hệ thống"
+
+#: src/models/filesystems.js:44
+msgid "All system libraries, executables and static data"
+msgstr "Tất cả thư viện hệ thống, tệp thực thi và dữ liệu tĩnh"
+
+#: src/models/filesystems.js:51
+msgid "All system configurations"
+msgstr "Tất cả cấu hình hệ thống"
+
+#: src/models/filesystems.js:58
+msgid "All user files"
+msgstr "Tất cả tệp người dùng"
+
+#: src/models/filesystems.js:83 src/models/filesystemsOther.js:64
+msgid "List of filesystem subsets available to the application"
+msgstr "Danh sách tập con hệ thống tệp có sẵn cho ứng dụng"
+
+#: src/models/filesystemsOther.js:39
+msgid "Other files"
+msgstr "Tệp khác"
+
+#: src/models/filesystemsOther.js:42
+msgid "e.g. ~/games:ro, xdg-pictures, etc"
+msgstr "ví dụ: ~/games:ro, xdg-pictures, v.v."
+
+#: src/models/persistent.js:37
+msgid "Files"
+msgstr "Tệp"
+
+#: src/models/persistent.js:40
+msgid "e.g. .thunderbird"
+msgstr "ví dụ: .thunderbird"
+
+#: src/models/persistent.js:62
+msgid "List of homedir-relative paths created in the sandbox"
+msgstr "Danh sách đường dẫn tương đối với thư mục home được tạo trong sandbox"
+
+#: src/models/portals.js:118
+msgid "Background"
+msgstr "Chạy nền"
+
+#: src/models/portals.js:120
+msgid "Can run in the background"
+msgstr "Có thể chạy trong nền"
+
+#: src/models/portals.js:128
+msgid "Notifications"
+msgstr "Thông báo"
+
+#: src/models/portals.js:130
+msgid "Can send notifications"
+msgstr "Có thể gửi thông báo"
+
+#: src/models/portals.js:138
+msgid "Microphone"
+msgstr "Micrô"
+
+#: src/models/portals.js:140
+msgid "Can listen to your microphone"
+msgstr "Có thể nghe từ micrô của bạn"
+
+#: src/models/portals.js:148
+msgid "Speakers"
+msgstr "Loa"
+
+#: src/models/portals.js:150
+msgid "Can play sounds to your speakers"
+msgstr "Có thể phát âm thanh qua loa của bạn"
+
+#: src/models/portals.js:158
+msgid "Camera"
+msgstr "Máy ảnh"
+
+#: src/models/portals.js:160
+msgid "Can record videos with your camera"
+msgstr "Có thể ghi hình bằng máy ảnh của bạn"
+
+#: src/models/portals.js:168
+msgid "Location"
+msgstr "Vị trí"
+
+#: src/models/portals.js:170
+msgid "Can access your location"
+msgstr "Có thể truy cập vị trí của bạn"
+
+#: src/models/portals.js:216
+msgid "List of resources selectively granted to the application"
+msgstr "Danh sách tài nguyên được cấp chọn lọc cho ứng dụng"
+
+#: src/models/portals.js:256 src/widgets/permissionEntryRow.js:58
+#: src/widgets/permissionSwitchRow.js:43
+msgid "Not supported by the installed version of Flatpak"
+msgstr "Không được hỗ trợ bởi phiên bản Flatpak đã cài đặt"
+
+#: src/models/portals.js:264
+msgid "Requires permission store version 2 or newer"
+msgstr "Yêu cầu kho quyền phiên bản 2 trở lên"
+
+#: src/models/portals.js:272
+msgid "Portal data has not been set up yet"
+msgstr "Dữ liệu portal chưa được thiết lập"
+
+#: src/models/shared.js:39
+msgid "Network"
+msgstr "Mạng"
+
+#: src/models/shared.js:46
+msgid "Inter-process communications"
+msgstr "Giao tiếp giữa các tiến trình"
+
+#: src/models/shared.js:79
+msgid "List of subsystems shared with the host system"
+msgstr "Danh sách hệ thống con được chia sẻ với hệ thống máy chủ"
+
+#: src/models/sockets.js:37
+msgid "X11 windowing system"
+msgstr "Hệ thống cửa sổ X11"
+
+#: src/models/sockets.js:44
+msgid "Wayland windowing system"
+msgstr "Hệ thống cửa sổ Wayland"
+
+#: src/models/sockets.js:51
+msgid "Fallback to X11 windowing system"
+msgstr "Dự phòng sang hệ thống cửa sổ X11"
+
+#: src/models/sockets.js:58
+msgid "PulseAudio sound server"
+msgstr "Máy chủ âm thanh PulseAudio"
+
+#: src/models/sockets.js:65
+msgid "D-Bus session bus"
+msgstr "D-Bus bus phiên"
+
+#: src/models/sockets.js:72
+msgid "D-Bus system bus"
+msgstr "D-Bus bus hệ thống"
+
+#: src/models/sockets.js:79
+msgid "Secure Shell agent"
+msgstr "Tác nhân Secure Shell"
+
+#: src/models/sockets.js:86
+msgid "Smart cards"
+msgstr "Thẻ thông minh"
+
+#: src/models/sockets.js:93
+msgid "Printing system"
+msgstr "Hệ thống in ấn"
+
+#: src/models/sockets.js:100
+msgid "GPG-Agent directories"
+msgstr "Thư mục GPG-Agent"
+
+#: src/models/sockets.js:107
+msgid "Inherit Wayland socket"
+msgstr "Kế thừa socket Wayland"
+
+#: src/models/sockets.js:132
+msgid "List of well-known sockets available in the sandbox"
+msgstr "Danh sách socket nổi tiếng có sẵn trong sandbox"
+
+#: src/models/variables.js:40
+msgid "Variables"
+msgstr "Biến"
+
+#: src/models/variables.js:43
+msgid "e.g. GTK_DEBUG=interactive"
+msgstr "ví dụ: GTK_DEBUG=interactive"
+
+#: src/models/variables.js:73
+msgid "List of variables exported to the application"
+msgstr "Danh sách biến được xuất sang ứng dụng"
+
+#. TRANSLATORS: <full-month-name> <day-of-month>, <year-with-century>
+#: src/widgets/appInfoViewer.js:61
+msgid "%B %e, %Y"
+msgstr "%e %B, %Y"
+
+#: src/widgets/appInfoViewer.ui:46
+msgid "Version"
+msgstr "Phiên bản"
+
+#: src/widgets/appInfoViewer.ui:59
+msgid "Last Updated"
+msgstr "Cập nhật lần cuối"
+
+#: src/widgets/appInfoViewer.ui:72
+msgid "Runtime"
+msgstr "Môi trường chạy"
+
+#: src/widgets/busNameRow.js:35 src/widgets/pathRow.js:73
+#: src/widgets/relativePathRow.js:33 src/widgets/variableRow.js:33
+msgid "This is not a valid option"
+msgstr "Đây không phải là tùy chọn hợp lệ"
+
+#: src/widgets/detailsButton.js:60
+msgid "_Show Details"
+msgstr "_Hiện chi tiết"
+
+#: src/widgets/detailsButton.js:107
+msgid "Show application in a software manager"
+msgstr "Hiện ứng dụng trong trình quản lý phần mềm"
+
+#: src/widgets/detailsButton.js:109
+msgid "No software manager found"
+msgstr "Không tìm thấy trình quản lý phần mềm"
+
+#: src/widgets/globalRow.ui:7 src/widgets/globalInfoViewer.ui:21
+msgid "All Applications"
+msgstr "Tất cả ứng dụng"
+
+#: src/widgets/globalInfoViewer.ui:32
+msgid "Changes that apply to all Flatpak applications"
+msgstr "Các thay đổi áp dụng cho tất cả ứng dụng Flatpak"
+
+#: src/widgets/globalInfoViewer.ui:55
+msgid "Flatpak Version"
+msgstr "Phiên bản Flatpak"
+
+#: src/widgets/globalInfoViewer.ui:68
+msgid "Portal Version"
+msgstr "Phiên bản Portal"
+
+#: src/widgets/globalInfoViewer.ui:81
+msgid "Changes Path"
+msgstr "Đường dẫn thay đổi"
+
+#: src/widgets/menu.ui:7
+msgid "_Help"
+msgstr "_Trợ giúp"
+
+#: src/widgets/menu.ui:11
+msgid "_Documentation"
+msgstr "_Tài liệu"
+
+#: src/widgets/menu.ui:15
+msgid "_Keyboard Shortcuts"
+msgstr "_Phím tắt"
+
+#: src/widgets/menu.ui:19
+msgid "_About Flatseal"
+msgstr "_Giới thiệu Flatseal"
+
+#: src/widgets/overrideStatusIcon.js:25
+msgid "Changed globally"
+msgstr "Đã thay đổi toàn cục"
+
+#: src/widgets/overrideStatusIcon.js:26
+msgid "Changed by the user"
+msgstr "Đã thay đổi bởi người dùng"
+
+#: src/widgets/pathRow.js:27
+msgid "this absolute path"
+msgstr "đường dẫn tuyệt đối này"
+
+#: src/widgets/pathRow.js:28
+msgid "this path relative to the home directory"
+msgstr "đường dẫn này tương đối với thư mục home"
+
+#: src/widgets/pathRow.js:29
+msgid "all system configurations"
+msgstr "tất cả cấu hình hệ thống"
+
+#: src/widgets/pathRow.js:30
+msgid "all system libraries, executables and static data"
+msgstr "tất cả thư viện hệ thống, tệp thực thi và dữ liệu tĩnh"
+
+#: src/widgets/pathRow.js:31
+msgid "all system files"
+msgstr "tất cả tệp hệ thống"
+
+#: src/widgets/pathRow.js:32
+msgid "all user files"
+msgstr "tất cả tệp người dùng"
+
+#: src/widgets/pathRow.js:33
+msgid "the desktop directory"
+msgstr "thư mục desktop"
+
+#: src/widgets/pathRow.js:34
+msgid "the documents directory"
+msgstr "thư mục documents"
+
+#: src/widgets/pathRow.js:35
+msgid "the download directory"
+msgstr "thư mục download"
+
+#: src/widgets/pathRow.js:36
+msgid "the music directory"
+msgstr "thư mục music"
+
+#: src/widgets/pathRow.js:37
+msgid "the pictures directory"
+msgstr "thư mục pictures"
+
+#: src/widgets/pathRow.js:38
+msgid "the public directory"
+msgstr "thư mục public"
+
+#: src/widgets/pathRow.js:39
+msgid "the videos directory"
+msgstr "thư mục videos"
+
+#: src/widgets/pathRow.js:40
+msgid "the templates directory"
+msgstr "thư mục templates"
+
+#: src/widgets/pathRow.js:41
+msgid "the config directory"
+msgstr "thư mục config"
+
+#: src/widgets/pathRow.js:42
+msgid "the cache directory"
+msgstr "thư mục cache"
+
+#: src/widgets/pathRow.js:43
+msgid "the data directory"
+msgstr "thư mục data"
+
+#: src/widgets/pathRow.js:44
+msgid "the runtime directory"
+msgstr "thư mục runtime"
+
+#: src/widgets/pathRow.js:59
+#, javascript-format
+msgid "Can read: %s"
+msgstr "Có thể đọc: %s"
+
+#: src/widgets/pathRow.js:60
+#, javascript-format
+msgid "Can modify and read: %s"
+msgstr "Có thể sửa đổi và đọc: %s"
+
+#: src/widgets/pathRow.js:61
+#, javascript-format
+msgid "Can create, modify and read: %s"
+msgstr "Có thể tạo, sửa đổi và đọc: %s"
+
+#: src/widgets/pathRow.js:67
+#, javascript-format
+msgid "Can't read: %s"
+msgstr "Không thể đọc: %s"
+
+#: src/widgets/pathRow.js:68
+#, javascript-format
+msgid "Can't modify or read: %s"
+msgstr "Không thể sửa đổi hoặc đọc: %s"
+
+#: src/widgets/pathRow.js:69 src/widgets/pathRow.js:70
+#, javascript-format
+msgid "Can't create, modify or read: %s"
+msgstr "Không thể tạo, sửa đổi hoặc đọc: %s"
+
+#: src/widgets/permissionPortalRow.ui:11
+msgid "Unset"
+msgstr "Bỏ thiết lập"
+
+#: src/widgets/relativePathRow.js:84
+msgid "Default paths can't be removed"
+msgstr "Không thể xóa đường dẫn mặc định"
+
+#: src/widgets/resetButton.js:37 src/widgets/resetButton.js:55
+#: src/widgets/resetButton.js:62 src/widgets/window.js:106
+msgid "_Reset"
+msgstr "Đặt _lại"
+
+#: src/widgets/resetButton.js:65
+msgid "No changes made to this application"
+msgstr "Chưa có thay đổi nào được thực hiện cho ứng dụng này"
+
+#: src/widgets/resetButton.js:68
+msgid "Reset this application permissions"
+msgstr "Đặt lại quyền của ứng dụng này"
+
+#: src/widgets/resetButton.js:70
+msgid ", including changes not made with Flatseal"
+msgstr ", bao gồm cả các thay đổi không được thực hiện bằng Flatseal"
+
+#: src/widgets/shortcutsWindow.ui:11
+msgid "General"
+msgstr "Chung"
+
+#: src/widgets/shortcutsWindow.ui:15
+msgid "Show mnemonics"
+msgstr "Hiện bộ gợi nhớ"
+
+#: src/widgets/shortcutsWindow.ui:21
+msgid "Show documentation"
+msgstr "Hiện tài liệu"
+
+#: src/widgets/shortcutsWindow.ui:27
+msgid "Show menu"
+msgstr "Hiện menu"
+
+#: src/widgets/shortcutsWindow.ui:33
+msgid "Keyboard shortcuts"
+msgstr "Phím tắt"
+
+#: src/widgets/shortcutsWindow.ui:39
+msgid "Quit"
+msgstr "Thoát"
+
+#: src/widgets/shortcutsWindow.ui:46
+msgid "Navigation"
+msgstr "Điều hướng"
+
+#: src/widgets/shortcutsWindow.ui:50
+msgid "Move left"
+msgstr "Di chuyển sang trái"
+
+#: src/widgets/shortcutsWindow.ui:56
+msgid "Move up"
+msgstr "Di chuyển lên trên"
+
+#: src/widgets/shortcutsWindow.ui:62
+msgid "Move right"
+msgstr "Di chuyển sang phải"
+
+#: src/widgets/shortcutsWindow.ui:68
+msgid "Move down"
+msgstr "Di chuyển xuống dưới"
+
+#: src/widgets/shortcutsWindow.ui:75 src/widgets/window.ui:21
+msgid "Applications"
+msgstr "Ứng dụng"
+
+#: src/widgets/shortcutsWindow.ui:79 src/widgets/shortcutsWindow.ui:101
+msgid "Find"
+msgstr "Tìm"
+
+#: src/widgets/shortcutsWindow.ui:86 src/widgets/window.ui:95
+msgid "Permissions"
+msgstr "Quyền"
+
+#: src/widgets/shortcutsWindow.ui:90
+msgid "Toggle"
+msgstr "Bật/tắt"
+
+#: src/widgets/shortcutsWindow.ui:97
+msgid "Documentation"
+msgstr "Tài liệu"
+
+#: src/widgets/shortcutsWindow.ui:107
+msgid "Find next"
+msgstr "Tìm tiếp"
+
+#: src/widgets/shortcutsWindow.ui:113
+msgid "Find previous"
+msgstr "Tìm trước"
+
+#: src/widgets/window.js:98
+msgid "Permissions have been reset"
+msgstr "Quyền đã được đặt lại"
+
+#: src/widgets/window.js:99
+msgid "_Undo"
+msgstr "_Hoàn tác"
+
+#: src/widgets/window.js:105
+msgid "Cannot load overrides due to incorrect contents"
+msgstr "Không thể tải ghi đè do nội dung không chính xác"
+
+#: src/widgets/window.js:112
+msgid "Refreshed due to changes in Flatpak installations"
+msgstr "Đã làm mới do thay đổi trong các cài đặt Flatpak"
+
+#: src/widgets/window.ui:31
+msgid "Main Menu"
+msgstr "Menu chính"
+
+#: src/widgets/window.ui:75
+msgid "No applications found."
+msgstr "Không tìm thấy ứng dụng nào."

--- a/po/vi.po
+++ b/po/vi.po
@@ -377,7 +377,7 @@ msgstr "_Trợ giúp"
 
 #: src/widgets/menu.ui:11
 msgid "_Documentation"
-msgstr "_Tài liệu"
+msgstr "Tài _liệu"
 
 #: src/widgets/menu.ui:15
 msgid "_Keyboard Shortcuts"

--- a/po/vi.po
+++ b/po/vi.po
@@ -1,12 +1,12 @@
 # Vietnamese translations for flatseal package.
 # Copyright (C) 2021 THE flatseal'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the flatseal package.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: flatseal\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-12 13:59-0300\n"
+"POT-Creation-Date: 2026-05-15 08:52-0300\n"
 "PO-Revision-Date: 2026-05-02 00:00+0700\n"
 "Last-Translator: \n"
 "Language-Team: Vietnamese\n"
@@ -323,10 +323,14 @@ msgid "Version"
 msgstr "Phiên bản"
 
 #: src/widgets/appInfoViewer.ui:59
+msgid "Identifier"
+msgstr "Mã định danh"
+
+#: src/widgets/appInfoViewer.ui:72
 msgid "Last Updated"
 msgstr "Cập nhật lần cuối"
 
-#: src/widgets/appInfoViewer.ui:72
+#: src/widgets/appInfoViewer.ui:85
 msgid "Runtime"
 msgstr "Môi trường chạy"
 
@@ -518,75 +522,75 @@ msgstr "Đặt lại quyền của ứng dụng này"
 msgid ", including changes not made with Flatseal"
 msgstr ", bao gồm cả các thay đổi không được thực hiện bằng Flatseal"
 
-#: src/widgets/shortcutsWindow.ui:11
+#: src/widgets/shortcutsWindow.ui:7
 msgid "General"
 msgstr "Chung"
 
-#: src/widgets/shortcutsWindow.ui:15
+#: src/widgets/shortcutsWindow.ui:11
 msgid "Show mnemonics"
 msgstr "Hiện bộ gợi nhớ"
 
-#: src/widgets/shortcutsWindow.ui:21
+#: src/widgets/shortcutsWindow.ui:17
 msgid "Show documentation"
 msgstr "Hiện tài liệu"
 
-#: src/widgets/shortcutsWindow.ui:27
+#: src/widgets/shortcutsWindow.ui:23
 msgid "Show menu"
 msgstr "Hiện menu"
 
-#: src/widgets/shortcutsWindow.ui:33
+#: src/widgets/shortcutsWindow.ui:29
 msgid "Keyboard shortcuts"
 msgstr "Phím tắt"
 
-#: src/widgets/shortcutsWindow.ui:39
+#: src/widgets/shortcutsWindow.ui:35
 msgid "Quit"
 msgstr "Thoát"
 
-#: src/widgets/shortcutsWindow.ui:46
+#: src/widgets/shortcutsWindow.ui:42
 msgid "Navigation"
 msgstr "Điều hướng"
 
-#: src/widgets/shortcutsWindow.ui:50
+#: src/widgets/shortcutsWindow.ui:46
 msgid "Move left"
 msgstr "Di chuyển sang trái"
 
-#: src/widgets/shortcutsWindow.ui:56
+#: src/widgets/shortcutsWindow.ui:52
 msgid "Move up"
 msgstr "Di chuyển lên trên"
 
-#: src/widgets/shortcutsWindow.ui:62
+#: src/widgets/shortcutsWindow.ui:58
 msgid "Move right"
 msgstr "Di chuyển sang phải"
 
-#: src/widgets/shortcutsWindow.ui:68
+#: src/widgets/shortcutsWindow.ui:64
 msgid "Move down"
 msgstr "Di chuyển xuống dưới"
 
-#: src/widgets/shortcutsWindow.ui:75 src/widgets/window.ui:21
+#: src/widgets/shortcutsWindow.ui:71 src/widgets/window.ui:21
 msgid "Applications"
 msgstr "Ứng dụng"
 
-#: src/widgets/shortcutsWindow.ui:79 src/widgets/shortcutsWindow.ui:101
+#: src/widgets/shortcutsWindow.ui:75 src/widgets/shortcutsWindow.ui:97
 msgid "Find"
 msgstr "Tìm"
 
-#: src/widgets/shortcutsWindow.ui:86 src/widgets/window.ui:95
+#: src/widgets/shortcutsWindow.ui:82 src/widgets/window.ui:95
 msgid "Permissions"
 msgstr "Quyền"
 
-#: src/widgets/shortcutsWindow.ui:90
+#: src/widgets/shortcutsWindow.ui:86
 msgid "Toggle"
 msgstr "Bật/tắt"
 
-#: src/widgets/shortcutsWindow.ui:97
+#: src/widgets/shortcutsWindow.ui:93
 msgid "Documentation"
 msgstr "Tài liệu"
 
-#: src/widgets/shortcutsWindow.ui:107
+#: src/widgets/shortcutsWindow.ui:103
 msgid "Find next"
 msgstr "Tìm tiếp"
 
-#: src/widgets/shortcutsWindow.ui:113
+#: src/widgets/shortcutsWindow.ui:109
 msgid "Find previous"
 msgstr "Tìm trước"
 


### PR DESCRIPTION
Add Vietnamese translation for Flatseal.

Changes:
- Add po/vi.po with complete Vietnamese translation
- Register Vietnamese in po/LINGUAS

All strings translated with proper mnemonic placement on typeable characters. Empty msgstr preserved only for untranslatable strings as marked by TRANSLATORS comments.