### PR TITLE
Fix missing device support in app metadata

### DIFF
--- a/src/widgets/appInfoViewer.js
+++ b/src/widgets/appInfoViewer.js
@@ -33,7 +33,7 @@ const styles = {
 var FlatsealAppInfoViewer = GObject.registerClass({
     GTypeName: 'FlatsealAppInfoViewer',
     Template: 'resource:///com/github/tchx84/Flatseal/widgets/appInfoViewer.ui',
-    InternalChildren: ['icon', 'name', 'author', 'version', 'identifier', 'released', 'runtime'],
+    InternalChildren: ['icon', 'name', 'author', 'version', 'identifier', 'released', 'runtime', 'devices'],
     Properties: {
         compact: GObject.ParamSpec.boolean(
             'compact',
@@ -70,6 +70,7 @@ var FlatsealAppInfoViewer = GObject.registerClass({
         this._version.set_label(appdata.version);
         this._identifier.set_label(appdata.appId);
         this._released.set_label(this._getFormattedDate(appdata.date));
+        this._devices.set_label(appdata.devices || '');
 
         this._icon.set_from_icon_name(desktop.icon);
 


### PR DESCRIPTION
The CHANGELOG mentions 'Fixed missing device support information in the app metadata' but the issue persists in the app info viewer. The FlatsealAppInfoViewer widget does not display device-related metadata (e.g., devices) from the appdata. Added a label to show device permissions from the application metadata, improving user insight into app permissions.