### PR TITLE
filesystem: Add host-root support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -84,6 +84,7 @@ Name | Type | Description | `flatpak override` equivalent
 All filesystem files | Toggle | Allow read-write access to the whole filesystem. Everything that isn't writeable by the user will be read-only | `--filesystem=host` and `--nofilesystem=host`
 All system libraries, executables and static data | Toggle | Allow read-write access to system libraries located in `/usr`. Since this directory requires root access to write, the permission will be read-only. | `--filesystem=host-os` and `--nofilesystem=host-os`
 All system configurations | Toggle | Allow read-write access to system configurations located in `/etc`. Since this directory requires root access to write, the permission will be read-only. | `--filesystem=host-etc` and `--nofilesystem=host-etc`
+Complete host filesystem | Toggle | Allow read-write access to the host filesystem, mounted at "/run/host/root" inside the sandbox | `--filesystem=host-root` and `--nofilesystem=host-root`
 All user files | Toggle | Allow read-write access to the user directory (`$HOME` or `~/`). | `--filesystem=home` and `--nofilesystem=home`
 Other files | Input | Allow read-write access to the directory you desire. <br /> <br /> For example, you would put `~/games` if you want read-write access to `~/games`. If you want read-only access to `~/games`, then you would put `~/games:ro`. | `--filesystem=[PATH]`, `--filesystem=[PATH]:ro` and `--nofilesystem=[PATH]`
 

--- a/help/C/index.html
+++ b/help/C/index.html
@@ -346,12 +346,18 @@
 <td><code>--filesystem=host-etc</code> and <code>--nofilesystem=host-etc</code></td>
 </tr>
 <tr class="even">
+<td>Complete host filesystem without exclusions</td>
+<td>Toggle</td>
+<td>Complete host filesystem with no exclusions, mounted at "/run/host/root" inside the sandbox</td>
+<td><code>--filesystem=host-root</code> and <code>--nofilesystem=host-root</code></td>
+</tr>
+<tr class="odd">
 <td>All user files</td>
 <td>Toggle</td>
 <td>Allow read-write access to the user directory (<code>$HOME</code> or <code>~/</code>).</td>
 <td><code>--filesystem=home</code> and <code>--nofilesystem=home</code></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>Other files</td>
 <td>Input</td>
 <td>Allow read-write access to the directory you desire. <br /> <br /> For example, you would put <code>~/games</code> if you want read-write access to <code>~/games</code>. If you want read-only access to <code>~/games</code>, then you would put <code>~/games:ro</code>.</td>

--- a/src/models/filesystems.js
+++ b/src/models/filesystems.js
@@ -53,6 +53,13 @@ var FlatpakFilesystemsModel = GObject.registerClass({
                 value: this.constructor.getDefault(),
                 example: 'filesystem=host-etc',
             },
+            'filesystems-host-root': {
+                supported: this._info.supports('1.17.0'),
+                description: _('Complete host filesystem mounted at "/run/host/root"'),
+                option: 'host-root',
+                value: this.constructor.getDefault(),
+                example: 'filesystem=host-root',
+            },
             'filesystems-home': {
                 supported: this._info.supports('0.4.0'),
                 description: _('All user files'),

--- a/tests/content/system/flatpak/app/com.test.Basic/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Basic/current/active/metadata
@@ -3,7 +3,7 @@ shared=network;ipc;
 sockets=x11;fallback-x11;wayland;pulseaudio;system-bus;session-bus;ssh-auth;pcsc;cups;gpg-agent;inherit-wayland-socket;
 devices=dri;input;kvm;shm;usb;all;
 features=bluetooth;devel;multiarch;canbus;per-app-dev-shm;
-filesystems=host;host-os;host-etc;home;~/test;
+filesystems=host;host-os;host-etc;host-root;home;~/test;
 persistent=.test;
 
 [Environment]

--- a/tests/content/system/flatpak/app/com.test.BasicNegated/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.BasicNegated/current/active/metadata
@@ -3,7 +3,7 @@ shared=!network;!ipc;
 sockets=!x11;!fallback-x11;!wayland;!pulseaudio;!system-bus;!session-bus;!ssh-auth;!pcsc;!cups;!gpg-agent;!inherit-wayland-socket;
 devices=!dri;!input;!kvm;!shm;!usb;!all;
 features=!bluetooth;!devel;!multiarch;!canbus;!per-app-dev-shm;
-filesystems=!host;!host-os;!host-etc;!home;!~/test;
+filesystems=!host;!host-os;!host-etc;!host-root;!home;!~/test;
 persistent=tset.
 
 [Environment]

--- a/tests/content/user/flatpak/overrides/com.test.Basic
+++ b/tests/content/user/flatpak/overrides/com.test.Basic
@@ -3,7 +3,7 @@ shared=!network;!ipc;
 sockets=!x11;!fallback-x11;!wayland;!pulseaudio;!system-bus;!session-bus;!ssh-auth;!pcsc;!cups;!gpg-agent;!inherit-wayland-socket;
 devices=!dri;!input;!kvm;!shm;!usb;!all;
 features=!bluetooth;!devel;!multiarch;!canbus;!per-app-dev-shm;
-filesystems=!host;!host-os;!host-etc;!home;!~/test;
+filesystems=!host;!host-os;!host-etc;!host-root;!home;!~/test;
 persistent=tset.
 
 [Environment]

--- a/tests/content/user/flatpak/overrides/com.test.BasicNegated
+++ b/tests/content/user/flatpak/overrides/com.test.BasicNegated
@@ -3,7 +3,7 @@ shared=network;ipc;
 sockets=x11;fallback-x11;wayland;pulseaudio;system-bus;session-bus;ssh-auth;pcsc;cups;gpg-agent;inherit-wayland-socket;
 devices=dri;input;kvm;shm;usb;all;
 features=bluetooth;devel;multiarch;canbus;per-app-dev-shm;
-filesystems=host;host-os;host-etc;home;~/test;
+filesystems=host;host-os;host-etc;host-root;home;~/test;
 persistent=.test;
 
 [Environment]

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -33,7 +33,7 @@ const {
 
 setup();
 
-const _totalPermissions = 41;
+const _totalPermissions = 42;
 
 const _basicAppId = 'com.test.Basic';
 const _basicNegatedAppId = 'com.test.BasicNegated';
@@ -194,6 +194,7 @@ describe('Model', function() {
         expect(permissionsDefault.filesystems_host).toBe(true);
         expect(permissionsDefault.filesystems_host_os).toBe(true);
         expect(permissionsDefault.filesystems_host_etc).toBe(true);
+        expect(permissionsDefault.filesystems_host_root).toBe(true);
         expect(permissionsDefault.filesystems_home).toBe(true);
         expect(permissionsDefault.filesystems_other).toEqual('~/test');
         expect(permissionsDefault.session_talk).toEqual('org.test.Service-1');
@@ -235,6 +236,7 @@ describe('Model', function() {
         expect(permissionsDefault.filesystems_host).toBe(false);
         expect(permissionsDefault.filesystems_host_os).toBe(false);
         expect(permissionsDefault.filesystems_host_etc).toBe(false);
+        expect(permissionsDefault.filesystems_host_root).toBe(false);
         expect(permissionsDefault.filesystems_home).toBe(false);
         expect(permissionsDefault.session_talk).toEqual('');
         expect(permissionsDefault.session_own).toEqual('');
@@ -274,6 +276,7 @@ describe('Model', function() {
         expect(permissionsDefault.filesystems_host).toBe(false);
         expect(permissionsDefault.filesystems_host_os).toBe(false);
         expect(permissionsDefault.filesystems_host_etc).toBe(false);
+        expect(permissionsDefault.filesystems_host_root).toBe(false);
         expect(permissionsDefault.filesystems_home).toBe(false);
         expect(permissionsDefault.filesystems_other).toEqual('!~/test');
         expect(permissionsDefault.session_talk).toEqual('');
@@ -315,6 +318,7 @@ describe('Model', function() {
         expect(permissionsDefault.filesystems_host).toBe(true);
         expect(permissionsDefault.filesystems_host_os).toBe(true);
         expect(permissionsDefault.filesystems_host_etc).toBe(true);
+        expect(permissionsDefault.filesystems_host_root).toBe(true);
         expect(permissionsDefault.filesystems_home).toBe(true);
         expect(permissionsDefault.filesystems_other).toEqual('');
         expect(permissionsDefault.session_talk).toEqual('org.test.Service-1');
@@ -377,6 +381,7 @@ describe('Model', function() {
         expect(permissionsDefault.filesystems_host).toBe(false);
         expect(permissionsDefault.filesystems_host_os).toBe(false);
         expect(permissionsDefault.filesystems_host_etc).toBe(false);
+        expect(permissionsDefault.filesystems_host_root).toBe(false);
         expect(permissionsDefault.filesystems_home).toBe(true);
         expect(permissionsDefault.filesystems_other).toEqual('~/tset');
         expect(permissionsDefault.session_talk).toEqual('org.test.Service-3');


### PR DESCRIPTION
This adds the new filesystem plermission `host-root`: https://docs.flatpak.org/en/latest/sandbox-permissions.html#filesystem-access

Honestly it's not helpful that much since sanboxed apps have to explicitly look in `/run/host/root`, but in case it becomes useful later.