### PR TITLE
i18n: Add zh_TW translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -22,6 +22,7 @@ ca
 tr
 fr
 zh_CN
+zh_TW
 ta
 uk
 vi

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,0 +1,617 @@
+# Chinese (Traditional) translation for Flatseal.
+# Copyright (C) 2026 Martin Abente Lahaye
+# This file is distributed under the same license as the flatseal package.
+# Alang Hsu <alang.hsu@gmail.com>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: flatseal\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-15 08:52-0300\n"
+"PO-Revision-Date: 2026-06-04 12:03+0800\n"
+"Last-Translator: Alang Hsu <alang.hsu@gmail.com>\n"
+"Language-Team: Chinese (Traditional) <zh_TW@li.org>\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. TRANSLATORS: Don't translate this text
+#: data/com.github.tchx84.Flatseal.desktop.in:3
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:4
+msgid "Flatseal"
+msgstr "Flatseal"
+
+#: data/com.github.tchx84.Flatseal.desktop.in:9
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:10
+msgid "Manage Flatpak permissions"
+msgstr "管理 Flatpak 權限"
+
+#: data/com.github.tchx84.Flatseal.desktop.in:14
+msgid "seal;sandbox;override;"
+msgstr "封存;沙箱;覆寫;"
+
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:12
+msgid ""
+"Flatseal is a graphical utility to review and modify permissions from your Flatpak applications."
+msgstr "Flatseal 是一套用來檢視與修改 Flatpak 應用程式權限的圖形化工具。"
+
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:21
+msgid "The Flatseal main window"
+msgstr "Flatseal 主視窗"
+
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:25
+msgid "Flatseal showing filesystem permissions"
+msgstr "Flatseal 顯示檔案系統權限"
+
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:29
+msgid "Flatseal showing global overrides"
+msgstr "Flatseal 顯示全域覆寫"
+
+#. TRANSLATORS: Don't translate this text
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:35
+#: data/com.github.tchx84.Flatseal.metainfo.xml.in:37
+msgid "Martin Abente Lahaye"
+msgstr "Martin Abente Lahaye"
+
+#: data/com.github.tchx84.Flatseal.gschema.xml:15
+msgid "Application ID that was last selected"
+msgstr "上次選取的應用程式 ID"
+
+#: src/models/applications.js:237 src/models/applications.js:298
+#: src/models/applications.js:299 src/models/applications.js:300
+#: src/widgets/globalInfoViewer.ui:105 src/widgets/globalInfoViewer.ui:119
+#: src/widgets/globalInfoViewer.ui:133
+msgid "Unknown"
+msgstr "未知"
+
+#: src/models/sessionBus.js:38 src/models/systemBus.js:37
+msgid "Talks"
+msgstr "對話"
+
+#: src/models/sessionBus.js:45 src/models/systemBus.js:44
+msgid "Owns"
+msgstr "擁有"
+
+#: src/models/sessionBus.js:82
+msgid "List of well-known names on the session bus"
+msgstr "工作階段匯流排上已知名稱的清單"
+
+#: src/models/systemBus.js:73
+msgid "List of well-known names on the system bus"
+msgstr "系統匯流排上已知名稱的清單"
+
+#: src/models/devices.js:37
+msgid "GPU acceleration"
+msgstr "GPU 加速"
+
+#: src/models/devices.js:44
+msgid "Input devices"
+msgstr "輸入裝置"
+
+#: src/models/devices.js:51
+msgid "Virtualization"
+msgstr "虛擬化"
+
+#: src/models/devices.js:58
+msgid "Shared memory"
+msgstr "共享記憶體"
+
+#: src/models/devices.js:65
+msgid "USB devices"
+msgstr "USB 裝置"
+
+#: src/models/devices.js:72
+msgid "All devices (e.g. webcam)"
+msgstr "所有裝置（例如網路攝影機）"
+
+#: src/models/devices.js:97
+msgid "List of devices available in the sandbox"
+msgstr "沙箱中可用的裝置清單"
+
+#: src/models/features.js:37
+msgid "Development syscalls (e.g. ptrace)"
+msgstr "開發系統呼叫（例如 ptrace）"
+
+#: src/models/features.js:44
+msgid "Programs from other architectures"
+msgstr "來自其他架構的程式"
+
+#: src/models/features.js:51
+msgid "Bluetooth"
+msgstr "藍牙"
+
+#: src/models/features.js:58
+msgid "Controller Area Network bus"
+msgstr "控制器區域網路匯流排"
+
+#: src/models/features.js:65
+msgid "Application Shared Memory"
+msgstr "應用程式共享記憶體"
+
+#: src/models/features.js:90
+msgid "List of features available to the application"
+msgstr "應用程式可用的功能清單"
+
+#: src/models/filesystems.js:37
+msgid "All system files"
+msgstr "所有系統檔案"
+
+#: src/models/filesystems.js:44
+msgid "All system libraries, executables and static data"
+msgstr "所有系統函式庫、可執行檔與靜態資料"
+
+#: src/models/filesystems.js:51
+msgid "All system configurations"
+msgstr "所有系統設定"
+
+#: src/models/filesystems.js:58
+msgid "All user files"
+msgstr "所有使用者檔案"
+
+#: src/models/filesystems.js:83 src/models/filesystemsOther.js:64
+msgid "List of filesystem subsets available to the application"
+msgstr "應用程式可用的檔案系統子集清單"
+
+#: src/models/filesystemsOther.js:39
+msgid "Other files"
+msgstr "其他檔案"
+
+#: src/models/filesystemsOther.js:42
+msgid "e.g. ~/games:ro, xdg-pictures, etc"
+msgstr "例如 ~/games:ro、xdg-pictures 等"
+
+#: src/models/persistent.js:37
+msgid "Files"
+msgstr "檔案"
+
+#: src/models/persistent.js:40
+msgid "e.g. .thunderbird"
+msgstr "例如 .thunderbird"
+
+#: src/models/persistent.js:62
+msgid "List of homedir-relative paths created in the sandbox"
+msgstr "沙箱中建立的相對於家目錄的路徑清單"
+
+#: src/models/portals.js:118
+msgid "Background"
+msgstr "背景"
+
+#: src/models/portals.js:120
+msgid "Can run in the background"
+msgstr "可在背景執行"
+
+#: src/models/portals.js:128
+msgid "Notifications"
+msgstr "通知"
+
+#: src/models/portals.js:130
+msgid "Can send notifications"
+msgstr "可傳送通知"
+
+#: src/models/portals.js:138
+msgid "Microphone"
+msgstr "麥克風"
+
+#: src/models/portals.js:140
+msgid "Can listen to your microphone"
+msgstr "可收聽您的麥克風"
+
+#: src/models/portals.js:148
+msgid "Speakers"
+msgstr "喇叭"
+
+#: src/models/portals.js:150
+msgid "Can play sounds to your speakers"
+msgstr "可對您的喇叭播放聲音"
+
+#: src/models/portals.js:158
+msgid "Camera"
+msgstr "攝影機"
+
+#: src/models/portals.js:160
+msgid "Can record videos with your camera"
+msgstr "可使用您的攝影機錄製影片"
+
+#: src/models/portals.js:168
+msgid "Location"
+msgstr "位置"
+
+#: src/models/portals.js:170
+msgid "Can access your location"
+msgstr "可存取您的位置"
+
+#: src/models/portals.js:216
+msgid "List of resources selectively granted to the application"
+msgstr "選擇性授權給應用程式的資源清單"
+
+#: src/models/portals.js:256 src/widgets/permissionEntryRow.js:58
+#: src/widgets/permissionSwitchRow.js:43
+msgid "Not supported by the installed version of Flatpak"
+msgstr "已安裝的 Flatpak 版本不支援"
+
+#: src/models/portals.js:264
+msgid "Requires permission store version 2 or newer"
+msgstr "需要權限儲存庫第 2 版或更新版本"
+
+#: src/models/portals.js:272
+msgid "Portal data has not been set up yet"
+msgstr "入口資料尚未設定"
+
+#: src/models/shared.js:39
+msgid "Network"
+msgstr "網路"
+
+#: src/models/shared.js:46
+msgid "Inter-process communications"
+msgstr "行程間通訊"
+
+#: src/models/shared.js:79
+msgid "List of subsystems shared with the host system"
+msgstr "與主機系統共享的子系統清單"
+
+#: src/models/sockets.js:37
+msgid "X11 windowing system"
+msgstr "X11 視窗系統"
+
+#: src/models/sockets.js:44
+msgid "Wayland windowing system"
+msgstr "Wayland 視窗系統"
+
+#: src/models/sockets.js:51
+msgid "Fallback to X11 windowing system"
+msgstr "X11 視窗系統後備"
+
+#: src/models/sockets.js:58
+msgid "PulseAudio sound server"
+msgstr "PulseAudio 音效伺服器"
+
+#: src/models/sockets.js:65
+msgid "D-Bus session bus"
+msgstr "D-Bus 工作階段匯流排"
+
+#: src/models/sockets.js:72
+msgid "D-Bus system bus"
+msgstr "D-Bus 系統匯流排"
+
+#: src/models/sockets.js:79
+msgid "Secure Shell agent"
+msgstr "Secure Shell 代理程式"
+
+#: src/models/sockets.js:86
+msgid "Smart cards"
+msgstr "智慧卡"
+
+#: src/models/sockets.js:93
+msgid "Printing system"
+msgstr "列印系統"
+
+#: src/models/sockets.js:100
+msgid "GPG-Agent directories"
+msgstr "GPG-Agent 目錄"
+
+#: src/models/sockets.js:107
+msgid "Inherit Wayland socket"
+msgstr "繼承 Wayland 通訊端"
+
+#: src/models/sockets.js:132
+msgid "List of well-known sockets available in the sandbox"
+msgstr "沙箱中可用的已知通訊端清單"
+
+#: src/models/variables.js:40
+msgid "Variables"
+msgstr "變數"
+
+#: src/models/variables.js:43
+msgid "e.g. GTK_DEBUG=interactive"
+msgstr "例如 GTK_DEBUG=interactive"
+
+#: src/models/variables.js:73
+msgid "List of variables exported to the application"
+msgstr "匯出至應用程式的變數清單"
+
+#. TRANSLATORS: <full-month-name> <day-of-month>, <year-with-century>
+#: src/widgets/appInfoViewer.js:61
+msgid "%B %e, %Y"
+msgstr "%Y 年 %m 月 %d 日"
+
+#: src/widgets/appInfoViewer.ui:46
+msgid "Version"
+msgstr "版本"
+
+#: src/widgets/appInfoViewer.ui:59
+msgid "Identifier"
+msgstr "識別碼"
+
+#: src/widgets/appInfoViewer.ui:72
+msgid "Last Updated"
+msgstr "上次更新"
+
+#: src/widgets/appInfoViewer.ui:85
+msgid "Runtime"
+msgstr "執行環境"
+
+#: src/widgets/busNameRow.js:35 src/widgets/pathRow.js:73
+#: src/widgets/relativePathRow.js:33 src/widgets/variableRow.js:33
+msgid "This is not a valid option"
+msgstr "這不是有效選項"
+
+#: src/widgets/detailsButton.js:60
+msgid "_Show Details"
+msgstr "顯示詳細資料(_S)"
+
+#: src/widgets/detailsButton.js:107
+msgid "Show application in a software manager"
+msgstr "在軟體管理員中顯示應用程式"
+
+#: src/widgets/detailsButton.js:109
+msgid "No software manager found"
+msgstr "找不到軟體管理員"
+
+#: src/widgets/globalRow.ui:7 src/widgets/globalInfoViewer.ui:21
+msgid "All Applications"
+msgstr "所有應用程式"
+
+#: src/widgets/globalInfoViewer.ui:32
+msgid "Changes that apply to all Flatpak applications"
+msgstr "套用至所有 Flatpak 應用程式的變更"
+
+#: src/widgets/globalInfoViewer.ui:55
+msgid "Flatpak Version"
+msgstr "Flatpak 版本"
+
+#: src/widgets/globalInfoViewer.ui:68
+msgid "Portal Version"
+msgstr "入口版本"
+
+#: src/widgets/globalInfoViewer.ui:81
+msgid "Changes Path"
+msgstr "變更路徑"
+
+#: src/widgets/menu.ui:7
+msgid "_Help"
+msgstr "說明(_H)"
+
+#: src/widgets/menu.ui:11
+msgid "_Documentation"
+msgstr "文件(_D)"
+
+#: src/widgets/menu.ui:15
+msgid "_Keyboard Shortcuts"
+msgstr "鍵盤快速鍵(_K)"
+
+#: src/widgets/menu.ui:19
+msgid "_About Flatseal"
+msgstr "關於 Flatseal(_A)"
+
+#: src/widgets/overrideStatusIcon.js:25
+msgid "Changed globally"
+msgstr "已全域變更"
+
+#: src/widgets/overrideStatusIcon.js:26
+msgid "Changed by the user"
+msgstr "已由使用者變更"
+
+#: src/widgets/pathRow.js:27
+msgid "this absolute path"
+msgstr "此絕對路徑"
+
+#: src/widgets/pathRow.js:28
+msgid "this path relative to the home directory"
+msgstr "此相對於家目錄的路徑"
+
+#: src/widgets/pathRow.js:29
+msgid "all system configurations"
+msgstr "所有系統設定"
+
+#: src/widgets/pathRow.js:30
+msgid "all system libraries, executables and static data"
+msgstr "所有系統函式庫、可執行檔與靜態資料"
+
+#: src/widgets/pathRow.js:31
+msgid "all system files"
+msgstr "所有系統檔案"
+
+#: src/widgets/pathRow.js:32
+msgid "all user files"
+msgstr "所有使用者檔案"
+
+#: src/widgets/pathRow.js:33
+msgid "the desktop directory"
+msgstr "桌面目錄"
+
+#: src/widgets/pathRow.js:34
+msgid "the documents directory"
+msgstr "文件目錄"
+
+#: src/widgets/pathRow.js:35
+msgid "the download directory"
+msgstr "下載目錄"
+
+#: src/widgets/pathRow.js:36
+msgid "the music directory"
+msgstr "音樂目錄"
+
+#: src/widgets/pathRow.js:37
+msgid "the pictures directory"
+msgstr "圖片目錄"
+
+#: src/widgets/pathRow.js:38
+msgid "the public directory"
+msgstr "公用目錄"
+
+#: src/widgets/pathRow.js:39
+msgid "the videos directory"
+msgstr "影片目錄"
+
+#: src/widgets/pathRow.js:40
+msgid "the templates directory"
+msgstr "範本目錄"
+
+#: src/widgets/pathRow.js:41
+msgid "the config directory"
+msgstr "設定目錄"
+
+#: src/widgets/pathRow.js:42
+msgid "the cache directory"
+msgstr "快取目錄"
+
+#: src/widgets/pathRow.js:43
+msgid "the data directory"
+msgstr "資料目錄"
+
+#: src/widgets/pathRow.js:44
+msgid "the runtime directory"
+msgstr "執行階段目錄"
+
+#: src/widgets/pathRow.js:59
+#, javascript-format
+msgid "Can read: %s"
+msgstr "可讀取：%s"
+
+#: src/widgets/pathRow.js:60
+#, javascript-format
+msgid "Can modify and read: %s"
+msgstr "可修改與讀取：%s"
+
+#: src/widgets/pathRow.js:61
+#, javascript-format
+msgid "Can create, modify and read: %s"
+msgstr "可建立、修改與讀取：%s"
+
+#: src/widgets/pathRow.js:67
+#, javascript-format
+msgid "Can't read: %s"
+msgstr "無法讀取：%s"
+
+#: src/widgets/pathRow.js:68
+#, javascript-format
+msgid "Can't modify or read: %s"
+msgstr "無法修改或讀取：%s"
+
+#: src/widgets/pathRow.js:69 src/widgets/pathRow.js:70
+#, javascript-format
+msgid "Can't create, modify or read: %s"
+msgstr "無法建立、修改或讀取：%s"
+
+#: src/widgets/permissionPortalRow.ui:11
+msgid "Unset"
+msgstr "未設定"
+
+#: src/widgets/relativePathRow.js:84
+msgid "Default paths can't be removed"
+msgstr "無法移除預設路徑"
+
+#: src/widgets/resetButton.js:37 src/widgets/resetButton.js:55
+#: src/widgets/resetButton.js:62 src/widgets/window.js:106
+msgid "_Reset"
+msgstr "重設(_R)"
+
+#: src/widgets/resetButton.js:65
+msgid "No changes made to this application"
+msgstr "未對此應用程式進行任何變更"
+
+#: src/widgets/resetButton.js:68
+msgid "Reset this application permissions"
+msgstr "重設此應用程式權限"
+
+#: src/widgets/resetButton.js:70
+msgid ", including changes not made with Flatseal"
+msgstr "，包括非經由 Flatseal 進行的變更"
+
+#: src/widgets/shortcutsWindow.ui:7
+msgid "General"
+msgstr "一般"
+
+#: src/widgets/shortcutsWindow.ui:11
+msgid "Show mnemonics"
+msgstr "顯示助憶鍵"
+
+#: src/widgets/shortcutsWindow.ui:17
+msgid "Show documentation"
+msgstr "顯示文件"
+
+#: src/widgets/shortcutsWindow.ui:23
+msgid "Show menu"
+msgstr "顯示選單"
+
+#: src/widgets/shortcutsWindow.ui:29
+msgid "Keyboard shortcuts"
+msgstr "鍵盤快速鍵"
+
+#: src/widgets/shortcutsWindow.ui:35
+msgid "Quit"
+msgstr "結束"
+
+#: src/widgets/shortcutsWindow.ui:42
+msgid "Navigation"
+msgstr "導覽"
+
+#: src/widgets/shortcutsWindow.ui:46
+msgid "Move left"
+msgstr "向左移"
+
+#: src/widgets/shortcutsWindow.ui:52
+msgid "Move up"
+msgstr "向上移"
+
+#: src/widgets/shortcutsWindow.ui:58
+msgid "Move right"
+msgstr "向右移"
+
+#: src/widgets/shortcutsWindow.ui:64
+msgid "Move down"
+msgstr "向下移"
+
+#: src/widgets/shortcutsWindow.ui:71 src/widgets/window.ui:21
+msgid "Applications"
+msgstr "應用程式"
+
+#: src/widgets/shortcutsWindow.ui:75 src/widgets/shortcutsWindow.ui:97
+msgid "Find"
+msgstr "尋找"
+
+#: src/widgets/shortcutsWindow.ui:82 src/widgets/window.ui:95
+msgid "Permissions"
+msgstr "權限"
+
+#: src/widgets/shortcutsWindow.ui:86
+msgid "Toggle"
+msgstr "切換"
+
+#: src/widgets/shortcutsWindow.ui:93
+msgid "Documentation"
+msgstr "文件"
+
+#: src/widgets/shortcutsWindow.ui:103
+msgid "Find next"
+msgstr "尋找下一個"
+
+#: src/widgets/shortcutsWindow.ui:109
+msgid "Find previous"
+msgstr "尋找上一個"
+
+#: src/widgets/window.js:98
+msgid "Permissions have been reset"
+msgstr "權限已重設"
+
+#: src/widgets/window.js:99
+msgid "_Undo"
+msgstr "復原(_U)"
+
+#: src/widgets/window.js:105
+msgid "Cannot load overrides due to incorrect contents"
+msgstr "因內容錯誤，無法載入覆寫"
+
+#: src/widgets/window.js:112
+msgid "Refreshed due to changes in Flatpak installations"
+msgstr "因 Flatpak 安裝變更已重新整理"
+
+#: src/widgets/window.ui:31
+msgid "Main Menu"
+msgstr "主選單"
+
+#: src/widgets/window.ui:75
+msgid "No applications found."
+msgstr "找不到應用程式。"


### PR DESCRIPTION
Add Traditional Chinese (zh_TW) translation.

- 145 msgid translated (100% coverage)
- Generated from upstream po/flatseal.pot (POT-Creation-Date: 2026-05-15)
- LINGUAS updated to register the new locale