### PR TITLE
models: Ignore conditional permissions when parsing overrides

### DIFF
--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -190,6 +190,8 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     .split(';');
 
                 values.forEach(option => {
+                    /* Flatseal does not support conditionals, but skips them
+                     * to avoid corrupting the overrides file. */
                     if (option.startsWith(CONDITIONAL_PREFIX))
                         return;
 

--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -107,6 +107,7 @@ function generate() {
 }
 
 var DELAY = 500;
+var CONDITIONAL_PREFIX = 'if:';
 
 var FlatpakPermissionsModel = GObject.registerClass({
     GTypeName: 'FlatpakPermissionsModel',
@@ -189,6 +190,9 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     .split(';');
 
                 values.forEach(option => {
+                    if (option.startsWith(CONDITIONAL_PREFIX))
+                        return;
+
                     model = this.constructor._find(`${group}_${key}_${option.replace('!', '')}`);
 
                     if (model === null)

--- a/tests/content/system/flatpak/app/com.test.Conditional/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Conditional/current/active/metadata
@@ -1,0 +1,8 @@
+[Application]
+name=com.test.Conditional
+runtime=org.gnome.Platform/x86_64/master
+sdk=org.gnome.Sdk/x86_64/master
+command=test
+
+[Context]
+sockets=x11;if:x11:!has-wayland;

--- a/tests/content/system/flatpak/app/com.test.Conditional/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Conditional/current/active/metadata
@@ -6,4 +6,3 @@ command=test
 
 [Context]
 sockets=x11;if:x11:!has-wayland;
-devices=all;

--- a/tests/content/system/flatpak/app/com.test.Conditional/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Conditional/current/active/metadata
@@ -6,3 +6,4 @@ command=test
 
 [Context]
 sockets=x11;if:x11:!has-wayland;
+devices=all;

--- a/tests/content/user/flatpak/overrides/com.test.Conditional
+++ b/tests/content/user/flatpak/overrides/com.test.Conditional
@@ -1,3 +1,2 @@
 [Context]
-sockets=!x11;if:x11:!has-wayland;
 devices=all;if:all:!has-input-device;

--- a/tests/content/user/flatpak/overrides/com.test.Conditional
+++ b/tests/content/user/flatpak/overrides/com.test.Conditional
@@ -1,0 +1,3 @@
+[Context]
+sockets=!x11;if:x11:!has-wayland;
+devices=all;if:all:!has-input-device;

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1472,8 +1472,9 @@ describe('Model', function() {
         GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
             const group = permissionsDefault.constructor.getGroupForProperty('sockets-x11');
             expect(has(_conditionalOverride, group, 'sockets', '!x11')).toBe(true);
-            expect(has(_conditionalOverride, group, 'devices', '!all')).toBe(true);
-            expect(hasInTotal(_conditionalOverride)).toEqual(2);
+            expect(has(_conditionalOverride, group, 'sockets', 'if:x11:!has-wayland')).toBe(false);
+            expect(has(_conditionalOverride, group, 'devices', 'if:all:!has-input-device')).toBe(false);
+            expect(hasInTotal(_conditionalOverride)).toEqual(1);
             done();
             return GLib.SOURCE_REMOVE;
         });

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1467,12 +1467,13 @@ describe('Model', function() {
 
         GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
         permissionsDefault.set_property('sockets-x11', false);
+        permissionsDefault.set_property('devices-all', false);
 
         GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
             const group = permissionsDefault.constructor.getGroupForProperty('sockets-x11');
             expect(has(_conditionalOverride, group, 'sockets', '!x11')).toBe(true);
-            expect(has(_conditionalOverride, group, 'sockets', 'if:x11:!has-wayland')).toBe(false);
-            expect(has(_conditionalOverride, group, 'devices', 'if:all:!has-input-device')).toBe(false);
+            expect(has(_conditionalOverride, group, 'devices', '!all')).toBe(true);
+            expect(hasInTotal(_conditionalOverride)).toEqual(2);
             done();
             return GLib.SOURCE_REMOVE;
         });

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1462,33 +1462,16 @@ describe('Model', function() {
     });
 
     it('does not write conditional permissions back', function(done) {
-        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
+        GLib.setenv('FLATPAK_USER_DIR', _user, true);
         permissionsDefault.appId = _conditionalAppId;
 
+        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
         permissionsDefault.set_property('sockets-x11', false);
 
         GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
             const group = permissionsDefault.constructor.getGroupForProperty('sockets-x11');
             expect(has(_conditionalOverride, group, 'sockets', '!x11')).toBe(true);
             expect(has(_conditionalOverride, group, 'sockets', 'if:x11:!has-wayland')).toBe(false);
-            done();
-            return GLib.SOURCE_REMOVE;
-        });
-
-        update();
-    });
-
-    it('does not write conditional overrides back', function(done) {
-        GLib.setenv('FLATPAK_USER_DIR', _user, true);
-        permissionsDefault.appId = _conditionalAppId;
-
-        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
-        expect(permissionsDefault.devices_all).toBe(true);
-        permissionsDefault.set_property('devices-all', false);
-
-        GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
-            const group = permissionsDefault.constructor.getGroupForProperty('sockets-x11');
-            expect(has(_conditionalOverride, group, 'sockets', '!x11')).toBe(true);
             expect(has(_conditionalOverride, group, 'devices', 'if:all:!has-input-device')).toBe(false);
             done();
             return GLib.SOURCE_REMOVE;

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -55,6 +55,7 @@ const _globalAppId = 'com.test.Global';
 const _globalRestoredAppId = 'com.test.GlobalRestored';
 const _statusesAppId = 'com.test.Statuses';
 const _malformedAppId = 'com.test.Malformed';
+const _conditionalAppId = 'com.test.Conditional';
 
 const _flatpakInfo = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info']);
 const _flatpakInfoOld = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info.old']);
@@ -82,6 +83,7 @@ const _environmentOverride = GLib.build_filenamev([_overrides, _environmentAppId
 const _busOverride = GLib.build_filenamev([_overrides, _busAppId]);
 const _filesystemWithModeOverride = GLib.build_filenamev([_overrides, _filesystemWithMode]);
 const _resetModeOverride = GLib.build_filenamev([_overrides, _resetModeId]);
+const _conditionalOverride = GLib.build_filenamev([_overrides, _conditionalAppId]);
 const _globalWithGlobalOverride = GLib.build_filenamev([_global, 'overrides', _globalAppId]);
 
 const _sessionGroup = 'Session Bus Policy';
@@ -134,6 +136,7 @@ describe('Model', function() {
         GLib.unlink(_busOverride);
         GLib.unlink(_filesystemWithModeOverride);
         GLib.unlink(_resetModeOverride);
+        GLib.unlink(_conditionalOverride);
         GLib.unlink(_globalWithGlobalOverride);
         GLib.unlink(_globalOverride);
     });
@@ -1445,6 +1448,48 @@ describe('Model', function() {
             permissionsDefault.appId = _filesystemWithMode;
             expect(permissionsDefault.filesystems_other).toEqual('xdg-documents:ro;home:ro');
 
+            done();
+            return GLib.SOURCE_REMOVE;
+        });
+
+        update();
+    });
+
+    it('ignores conditional permissions', function() {
+        permissionsDefault.appId = _conditionalAppId;
+
+        expect(permissionsDefault.sockets_x11).toBe(true);
+    });
+
+    it('does not write conditional permissions back', function(done) {
+        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
+        permissionsDefault.appId = _conditionalAppId;
+
+        permissionsDefault.set_property('sockets-x11', false);
+
+        GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
+            const group = permissionsDefault.constructor.getGroupForProperty('sockets-x11');
+            expect(has(_conditionalOverride, group, 'sockets', '!x11')).toBe(true);
+            expect(has(_conditionalOverride, group, 'sockets', 'if:x11:!has-wayland')).toBe(false);
+            done();
+            return GLib.SOURCE_REMOVE;
+        });
+
+        update();
+    });
+
+    it('does not write conditional overrides back', function(done) {
+        GLib.setenv('FLATPAK_USER_DIR', _user, true);
+        permissionsDefault.appId = _conditionalAppId;
+
+        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
+        expect(permissionsDefault.devices_all).toBe(true);
+        permissionsDefault.set_property('devices-all', false);
+
+        GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
+            const group = permissionsDefault.constructor.getGroupForProperty('sockets-x11');
+            expect(has(_conditionalOverride, group, 'sockets', '!x11')).toBe(true);
+            expect(has(_conditionalOverride, group, 'devices', 'if:all:!has-input-device')).toBe(false);
             done();
             return GLib.SOURCE_REMOVE;
         });

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1465,6 +1465,9 @@ describe('Model', function() {
         GLib.setenv('FLATPAK_USER_DIR', _user, true);
         permissionsDefault.appId = _conditionalAppId;
 
+        expect(permissionsDefault.sockets_x11).toBe(true);
+        expect(permissionsDefault.devices_all).toBe(true);
+
         GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
         permissionsDefault.set_property('sockets-x11', false);
         permissionsDefault.set_property('devices-all', false);


### PR DESCRIPTION
  Flatpak 1.17+ introduced conditional permissions (e.g. `--socket-if=x11:!has-wayland`). Flatseal was not aware of this syntax, causing the conditional part to be dropped  and the override file to be written incorrectly.
  
This change makes Flatseal skip any permission value starting with `if:` when parsing override files, so the file remains valid. Supporting conditional permissions is out of scope for now.

Includes a unit test to verify the behavior.

