### PR TITLE
fix: USB portal support fixes and test coverage

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -12,6 +12,7 @@
 	- [Environment](#environment)
 	- [System Bus](#system-bus)
 	- [Session Bus](#system-bus)
+	- [USB](#usb)
 	- [Portals](#portals)
 - [Tips and Tricks](#tips-and-tricks)
 	- [Manually reset Flatseal permissions](#manually-reset-flatseal-permissions)
@@ -112,6 +113,13 @@ Name | Type | Description | `flatpak override` equivalent
 --- | --- | --- | ---
 Talks | Input | Allow the application to talk to session services. <br /> <br /> For example, adding `org.freedesktop.Notifications` will allow the application to send notifications. | `--talk-name=[NAME]`
 Owns | Input | Allow the application to own session services under the given name. | `--own-name=[NAME]`
+
+### USB
+
+Name | Type | Description | `flatpak override` equivalent
+--- | --- | --- | ---
+Allowed devices | Input | Allow the application to access specific USB devices through the portal. <br /> <br /> Devices are identified by vendor id, device id, and/or class, e.g. `vnd:0123` matches all devices from vendor `0123`, and `all` matches every USB device. | `--usb=[QUERY]`
+Blocked devices | Input | Deny the application access to specific USB devices through the portal, even if they would otherwise be allowed.<br /> <br /> If a device exists in both the allowed and blocked list, the blocked list takes precedence and access is denied. | `--nousb=[QUERY]`
 
 ### Portals
 

--- a/help/C/index.html
+++ b/help/C/index.html
@@ -61,6 +61,9 @@
 <a href="#system-bus">Session Bus</a>
 </li>
 <li>
+<a href="#usb">USB</a>
+</li>
+<li>
 <a href="#portals">Portals</a>
 </li>
 </ul>
@@ -468,6 +471,37 @@
 <td>Input</td>
 <td>Allow the application to own session services under the given name.</td>
 <td><code>--own-name=[NAME]</code></td>
+</tr>
+</tbody>
+</table>
+<h3 id="usb">USB</h3>
+<table>
+<colgroup>
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+<th><code>flatpak override</code> equivalent</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Allowed devices</td>
+<td>Input</td>
+<td>Allow the application to access specific USB devices through the portal. <br /> <br /> Devices are identified by vendor id, device id, and/or class, e.g. <code>vnd:0123</code> matches all devices from vendor <code>0123</code>, and <code>all</code> matches every USB device.</td>
+<td><code>--usb=[QUERY]</code></td>
+</tr>
+<tr class="even">
+<td>Blocked devices</td>
+<td>Input</td>
+<td>Deny the application access to specific USB devices through the portal, even if they would otherwise be allowed. <br /> <br /> If a device exists in both the allowed and blocked list, the blocked list takes precedence and access is denied. </td>
+<td><code>--nousb=[QUERY]</code></td>
 </tr>
 </tbody>
 </table>

--- a/src/com.github.tchx84.Flatseal.data.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.data.gresource.xml
@@ -18,6 +18,7 @@
     <file>widgets/permissionSwitchRow.ui</file>
     <file>widgets/relativePathRow.ui</file>
     <file alias="shortcuts-dialog.ui">widgets/shortcutsWindow.ui</file>
+    <file>widgets/usbRow.ui</file>
     <file>widgets/variableRow.ui</file>
     <file>widgets/window.ui</file>
   </gresource>

--- a/src/com.github.tchx84.Flatseal.src.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.src.gresource.xml
@@ -38,6 +38,7 @@
     <file>models/shared.js</file>
     <file>models/sockets.js</file>
     <file>models/systemBus.js</file>
+    <file>models/usb.js</file>
     <file>models/variables.js</file>
   </gresource>
 </gresources>

--- a/src/com.github.tchx84.Flatseal.src.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.src.gresource.xml
@@ -19,6 +19,7 @@
     <file>widgets/permissionSwitchRow.js</file>
     <file>widgets/relativePathRow.js</file>
     <file>widgets/resetButton.js</file>
+    <file>widgets/usbRow.js</file>
     <file>widgets/variableRow.js</file>
     <file>widgets/window.js</file>
     <file>models/applications.js</file>

--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -29,6 +29,7 @@ const {FlatpakFilesystemsOtherModel} = imports.models.filesystemsOther;
 const {FlatpakVariablesModel} = imports.models.variables;
 const {FlatpakSessionBusModel} = imports.models.sessionBus;
 const {FlatpakSystemBusModel} = imports.models.systemBus;
+const {FlatpakUsbModel} = imports.models.usb;
 const {FlatsealOverrideStatus} = imports.models.overrideStatus;
 const {isGlobalOverride} = imports.models.globalModel;
 const {applications, filesystems, persistent, portals} = imports.models;
@@ -46,6 +47,7 @@ const MODELS = {
     variables: new FlatpakVariablesModel(),
     system: new FlatpakSystemBusModel(),
     session: new FlatpakSessionBusModel(),
+    usb: new FlatpakUsbModel(),
     portals: portals.getDefault(),
     unsupported: new FlatpakUnsupportedModel(),
 };

--- a/src/models/usb.js
+++ b/src/models/usb.js
@@ -1,0 +1,118 @@
+/* exported FlatpakUsbModel */
+
+/* usb.js
+ *
+ * Copyright 2025 Martin Abente Lahaye
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const {GObject} = imports.gi;
+
+const {FlatpakSharedModel} = imports.models.shared;
+const {FlatsealOverrideStatus} = imports.models.overrideStatus;
+
+var FlatpakUsbModel = GObject.registerClass({
+    GTypeName: 'FlatpakUsbModel',
+}, class FlatpakUsbModel extends FlatpakSharedModel {
+    _init() {
+        super._init({});
+        this.reset();
+    }
+
+    getPermissions() {
+        return {
+            usb: {
+                supported: this._info.supports('1.15.11'),
+                description: _('Devices'),
+                option: null,
+                value: this.constructor.getDefault(),
+                example: _('e.g. vnd:0123+dev:4567'),
+            },
+        };
+    }
+
+    static getDefault() {
+        return '';
+    }
+
+    static getType() {
+        return 'usb';
+    }
+
+    static getGroup() {
+        return 'USB Devices';
+    }
+
+    static getKey() {
+        return 'enumerable-devices';
+    }
+
+    static getStyle() {
+        return 'usb';
+    }
+
+    static getTitle() {
+        return 'USB';
+    }
+
+    static getDescription() {
+        return _('List of devices matching the query visible to the USB portal');
+    }
+
+    getOptions() { // eslint-disable-line class-methods-use-this
+        return null;
+    }
+
+    static isNegated(value) {
+        return value.startsWith('!');
+    }
+
+    static negate(value) {
+        if (this.isNegated(value))
+            return value.replace('!', '');
+        return `!${value}`;
+    }
+
+    updateFromProxyProperty(property, value) {
+        const values = new Set(this.constructor.deserialize(value));
+
+        const baseline = this._originals.union(this._globals);
+        const added = values.difference(baseline);
+        const removed = new Set([...baseline.difference(values)]
+            .map(d => this.constructor.negate(d)));
+
+        this._overrides = added.union(removed);
+    }
+
+    updateStatusProperty(proxy) {
+        const statuses = this.constructor.deserialize(proxy.usb)
+            .map(d => this._getStatusForPermission(d));
+
+        proxy.set_property('usb-status', this.constructor.serialize(statuses));
+    }
+
+    updateProxyProperty(proxy) {
+        const originals = [...this._originals]
+            .filter(o => !this._globals.has(this.constructor.negate(o)))
+            .filter(o => !this._overrides.has(this.constructor.negate(o)));
+
+        const globals = [...this._globals]
+            .filter(g => !this._overrides.has(this.constructor.negate(g)));
+
+        const usb = [...originals, ...globals, ...this._overrides];
+
+        proxy.set_property('usb', this.constructor.serialize(usb));
+    }
+});

--- a/src/models/usb.js
+++ b/src/models/usb.js
@@ -3,6 +3,7 @@
 /* usb.js
  *
  * Copyright 2025 Martin Abente Lahaye
+ * Copyright 2026 Malika Odeny Asman
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +36,14 @@ var FlatpakUsbModel = GObject.registerClass({
         return {
             usb: {
                 supported: this._info.supports('1.15.11'),
-                description: _('Devices'),
+                description: _('Allowed devices'),
+                option: null,
+                value: this.constructor.getDefault(),
+                example: _('e.g. vnd:0123+dev:4567'),
+            },
+            'usb-hidden': {
+                supported: this._info.supports('1.15.11'),
+                description: _('Blocked devices'),
                 option: null,
                 value: this.constructor.getDefault(),
                 example: _('e.g. vnd:0123+dev:4567'),
@@ -56,7 +64,7 @@ var FlatpakUsbModel = GObject.registerClass({
     }
 
     static getKey() {
-        return 'enumerable-devices';
+        return null;
     }
 
     static getStyle() {
@@ -68,51 +76,104 @@ var FlatpakUsbModel = GObject.registerClass({
     }
 
     static getDescription() {
-        return _('List of devices matching the query visible to the USB portal');
+        return _('List of USB devices accessible through the portal');
     }
 
     getOptions() { // eslint-disable-line class-methods-use-this
         return null;
     }
 
-    static isNegated(value) {
-        return value.startsWith('!');
+    reset() {
+        super.reset();
+        this._hiddenOriginals = new Set();
+        this._hiddenGlobals = new Set();
+        this._hiddenOverrides = new Set();
     }
 
-    static negate(value) {
-        if (this.isNegated(value))
-            return value.replace('!', '');
-        return `!${value}`;
+    _findProperHiddenSet(overrides, global) {
+        if (overrides && global)
+            return this._hiddenGlobals;
+        if (overrides && !global)
+            return this._hiddenOverrides;
+        return this._hiddenOriginals;
+    }
+
+    _getHiddenStatusForDevice(device) {
+        let status = FlatsealOverrideStatus.ORIGINAL;
+        if (this._hiddenGlobals.has(device))
+            status = FlatsealOverrideStatus.GLOBAL;
+        if (this._hiddenOverrides.has(device))
+            status = FlatsealOverrideStatus.USER;
+        return status;
     }
 
     updateFromProxyProperty(property, value) {
-        const values = new Set(this.constructor.deserialize(value));
+        const devices = new Set(this.constructor.deserialize(value)
+            .filter(d => d.length !== 0));
 
-        const baseline = this._originals.union(this._globals);
-        const added = values.difference(baseline);
-        const removed = new Set([...baseline.difference(values)]
-            .map(d => this.constructor.negate(d)));
-
-        this._overrides = added.union(removed);
+        if (property === 'usb') {
+            this._overrides = new Set([...devices]
+                .filter(d => !this._originals.has(d))
+                .filter(d => !this._globals.has(d)));
+        } else if (property === 'usb-hidden') {
+            this._hiddenOverrides = new Set([...devices]
+                .filter(d => !this._hiddenOriginals.has(d))
+                .filter(d => !this._hiddenGlobals.has(d)));
+        }
     }
 
     updateStatusProperty(proxy) {
-        const statuses = this.constructor.deserialize(proxy.usb)
+        const usbStatuses = this.constructor.deserialize(proxy.usb)
+            .filter(d => d.length !== 0)
             .map(d => this._getStatusForPermission(d));
+        proxy.set_property('usb-status', this.constructor.serialize(usbStatuses));
 
-        proxy.set_property('usb-status', this.constructor.serialize(statuses));
+        const hiddenStatuses = this.constructor.deserialize(proxy.usb_hidden)
+            .filter(d => d.length !== 0)
+            .map(d => this._getHiddenStatusForDevice(d));
+        proxy.set_property('usb-hidden-status', this.constructor.serialize(hiddenStatuses));
     }
 
     updateProxyProperty(proxy) {
-        const originals = [...this._originals]
-            .filter(o => !this._globals.has(this.constructor.negate(o)))
-            .filter(o => !this._overrides.has(this.constructor.negate(o)));
+        const allowed = new Set([...this._originals, ...this._globals, ...this._overrides]);
+        const blocked = new Set([...this._hiddenOriginals, ...this._hiddenGlobals, ...this._hiddenOverrides]);
 
-        const globals = [...this._globals]
-            .filter(g => !this._overrides.has(this.constructor.negate(g)));
+        proxy.set_property('usb', this.constructor.serialize([...allowed]));
+        proxy.set_property('usb-hidden', this.constructor.serialize([...blocked]));
+    }
 
-        const usb = [...originals, ...globals, ...this._overrides];
+    loadFromKeyFile(group, key, value, overrides, global) {
+        const devices = this.constructor.deserialize(value)
+            .filter(d => d.length !== 0);
 
-        proxy.set_property('usb', this.constructor.serialize(usb));
+        if (key === 'enumerable-devices') {
+            const set = this._findProperSet(overrides, global);
+            devices.forEach(d => set.add(d));
+        } else if (key === 'hidden-devices') {
+            const set = this._findProperHiddenSet(overrides, global);
+            devices.forEach(d => set.add(d));
+        }
+    }
+
+    saveToKeyFile(keyFile) {
+        const group = this.constructor.getGroup();
+
+        this._overrides.forEach(value => {
+            try {
+                const existing = keyFile.get_value(group, 'enumerable-devices');
+                keyFile.set_value(group, 'enumerable-devices', `${value};${existing}`);
+            } catch (err) {
+                keyFile.set_value(group, 'enumerable-devices', `${value}`);
+            }
+        });
+
+        this._hiddenOverrides.forEach(value => {
+            try {
+                const existing = keyFile.get_value(group, 'hidden-devices');
+                keyFile.set_value(group, 'hidden-devices', `${value};${existing}`);
+            } catch (err) {
+                keyFile.set_value(group, 'hidden-devices', `${value}`);
+            }
+        });
     }
 });

--- a/src/style.css
+++ b/src/style.css
@@ -23,7 +23,8 @@ row .status.global {
 
 row .content .bus .info,
 row .content .variable .info,
-row .content .path .info {
+row .content .path .info,
+row .content .usb .info {
     padding: 8px;
     color: @accent_color;
     background-color: transparent;
@@ -35,13 +36,15 @@ row .content .path .info {
 
 row .content .relative.path .info,
 row .content .bus .info,
-row .content .variable .info {
+row .content .variable .info,
+row .content .usb .info {
     background-image: -gtk-icontheme("object-select-symbolic");
 }
 
 row .content .bus.not-valid .info,
 row .content .variable.not-valid .info,
-row .content .path.not-valid .info {
+row .content .path.not-valid .info,
+row .content .usb.not-valid .info {
     color: @warning_color;
     background-image: -gtk-icontheme("dialog-warning-symbolic");
 }

--- a/src/widgets/usbRow.js
+++ b/src/widgets/usbRow.js
@@ -1,0 +1,122 @@
+/* exported FlatsealUsbRow validity */
+
+/* usbRow.js
+ *
+ * Copyright 2025 Martin Abente Lahaye
+ * Copyright 2026 Malika Odeny Asman
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const {GObject, Gtk} = imports.gi;
+
+const {FlatsealOverrideStatusIcon} = imports.widgets.overrideStatusIcon;
+const {FlatsealOverrideStatus} = imports.models.overrideStatus;
+
+const _propFlags = GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT;
+
+/* https://github.com/flatpak/flatpak/blob/main/doc/flatpak-build-finish.xml */
+const _deviceExp = '(vnd:[0-9a-fA-F]{4}|dev:[0-9a-fA-F]{4}|cls:[0-9a-fA-F]{2}:(?:[0-9a-fA-F]{2}|\\*))';
+const EXP = new RegExp(`^(?!(?=.*dev:)(?!.*vnd:))(all|${_deviceExp}(\\+${_deviceExp})*)$`);
+
+var validity = {
+    VALID: 'valid',
+    NOTVALID: 'not-valid',
+};
+
+const _notValidMsg = _('This is not a valid option');
+
+
+var FlatsealUsbRow = GObject.registerClass({
+    GTypeName: 'FlatsealUsbRow',
+    Template: 'resource:///com/github/tchx84/Flatseal/widgets/usbRow.ui',
+    InternalChildren: ['entry', 'button', 'image', 'statusBox'],
+    Properties: {
+        text: GObject.ParamSpec.string(
+            'text',
+            'text',
+            'text',
+            _propFlags, ''),
+    },
+    Signals: {
+        'remove-requested': {},
+    },
+}, class FlatsealUsbRow extends Gtk.Box {
+    _init() {
+        super._init({});
+        this._setup();
+    }
+
+    _setup() {
+        this._expression = new RegExp(EXP);
+
+        this._entry.connect('notify::text', this._changed.bind(this));
+        this._button.connect('clicked', this._remove.bind(this));
+
+        this._statusIcon = new FlatsealOverrideStatusIcon();
+        this._statusBox.append(this._statusIcon);
+
+        this._validate();
+    }
+
+    _remove() {
+        this.emit('remove-requested');
+    }
+
+    _changed() {
+        this._validate();
+        this.notify('text');
+    }
+
+    _validate() {
+        const context = this.get_style_context();
+
+        if (context.has_class(validity.VALID))
+            context.remove_class(validity.VALID);
+        else if (context.has_class(validity.NOTVALID))
+            context.remove_class(validity.NOTVALID);
+
+        if (this._expression.test(this.text)) {
+            context.add_class(validity.VALID);
+            this._image.set_tooltip_text('');
+        } else {
+            context.add_class(validity.NOTVALID);
+            this._image.set_tooltip_text(_notValidMsg);
+        }
+    }
+
+    get text() {
+        if (!this._entry)
+            return '';
+        return this._entry.get_text();
+    }
+
+    set text(text) {
+        if (this.text === text)
+            return;
+        this._entry.set_text(text);
+    }
+
+    get status() {
+        return this._statusIcon.status;
+    }
+
+    set status(status) {
+        this._statusIcon.status = status;
+
+        /* only user-added entries can be edited or removed; original and
+         * global entries have no override to change and would have no effect */
+        this.sensitive = status === FlatsealOverrideStatus.USER;
+    }
+});

--- a/src/widgets/usbRow.ui
+++ b/src/widgets/usbRow.ui
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="FlatsealUsbRow" parent="GtkBox">
+    <property name="margin-bottom">12</property>
+    <child>
+      <object class="GtkImage" id="image">
+        <property name="vexpand">True</property>
+        <property name="valign">center</property>
+        <style>
+          <class name="info"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkEntry" id="entry">
+        <property name="hexpand">True</property>
+        <property name="vexpand">True</property>
+        <property name="valign">center</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox" id="statusBox">
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="orientation">vertical</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="button">
+        <property name="valign">center</property>
+        <property name="icon-name">window-close-symbolic</property>
+        <style>
+          <class name="flat"/>
+        </style>
+      </object>
+    </child>
+    <style>
+      <class name="usb"/>
+    </style>
+  </template>
+</interface>

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -244,6 +244,15 @@ var FlatsealWindow = GObject.registerClass({
                     p.value,
                     p.portalTable,
                     p.portalId);
+            } else if (p.type === 'usb') {
+                row = new FlatsealPermissionEntryRow(
+                    p.description,
+                    p.permission,
+                    p.value,
+                    p.serializeFunc,
+                    p.deserializeFunc,
+                    FlatsealBusNameRow,
+                    'list-add-symbolic');
             } else {
                 property = 'active';
                 row = new FlatsealPermissionSwitchRow(

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -35,6 +35,7 @@ const {FlatsealPathRow} = imports.widgets.pathRow;
 const {FlatsealRelativePathRow} = imports.widgets.relativePathRow;
 const {FlatsealVariableRow} = imports.widgets.variableRow;
 const {FlatsealBusNameRow} = imports.widgets.busNameRow;
+const {FlatsealUsbRow} = imports.widgets.usbRow;
 const {FlatsealSettingsModel} = imports.models.settings;
 const {isGlobalOverride} = imports.models.globalModel;
 
@@ -251,7 +252,7 @@ var FlatsealWindow = GObject.registerClass({
                     p.value,
                     p.serializeFunc,
                     p.deserializeFunc,
-                    FlatsealBusNameRow,
+                    FlatsealUsbRow,
                     'list-add-symbolic');
             } else {
                 property = 'active';

--- a/tests/content/global/flatpak/overrides/global
+++ b/tests/content/global/flatpak/overrides/global
@@ -11,3 +11,6 @@ TEST3=global
 [Session Bus Policy]
 org.test.Service-1=none
 org.test.Service-3=talk
+
+[USB Devices]
+enumerable-devices=vnd:0567;

--- a/tests/content/statuses/flatpak/overrides/com.test.Usb
+++ b/tests/content/statuses/flatpak/overrides/com.test.Usb
@@ -1,0 +1,3 @@
+[USB Devices]
+enumerable-devices=vnd:0789;
+hidden-devices=vnd:0111;

--- a/tests/content/statuses/flatpak/overrides/global
+++ b/tests/content/statuses/flatpak/overrides/global
@@ -10,3 +10,6 @@ TEST1=global
 [Session Bus Policy]
 org.test.Service-3=talk
 org.test.Service-4=own
+
+[USB Devices]
+enumerable-devices=vnd:0456;

--- a/tests/content/system/flatpak/app/com.test.Usb/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Usb/current/active/metadata
@@ -1,0 +1,7 @@
+[Application]
+name=com.test.Usb
+runtime=org.test.Platform
+
+[USB Devices]
+enumerable-devices=vnd:0123;
+hidden-devices=vnd:0408+dev:5348;

--- a/tests/content/user/flatpak/overrides/com.test.Usb
+++ b/tests/content/user/flatpak/overrides/com.test.Usb
@@ -1,0 +1,3 @@
+[USB Devices]
+enumerable-devices=vnd:0456;
+hidden-devices=vnd:0789;

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -33,7 +33,7 @@ const {
 
 setup();
 
-const _totalPermissions = 41;
+const _totalPermissions = 43;
 
 const _basicAppId = 'com.test.Basic';
 const _basicNegatedAppId = 'com.test.BasicNegated';
@@ -47,6 +47,7 @@ const _overridenAppId = 'com.test.Overriden';
 const _extraAppId = 'com.test.Extra';
 const _environmentAppId = 'com.test.Environment';
 const _busAppId = 'com.test.Bus';
+const _usbAppId = 'com.test.Usb';
 const _variablesAppId = 'com.test.Variables';
 const _trailingSemicolonId = 'com.test.TrailingSemicolon';
 const _filesystemWithMode = 'com.test.FilesystemWithMode';
@@ -81,6 +82,7 @@ const _unsupportedOverride = GLib.build_filenamev([_overrides, _unsupportedAppId
 const _overridenOverride = GLib.build_filenamev([_overrides, _overridenAppId]);
 const _environmentOverride = GLib.build_filenamev([_overrides, _environmentAppId]);
 const _busOverride = GLib.build_filenamev([_overrides, _busAppId]);
+const _usbOverride = GLib.build_filenamev([_overrides, _usbAppId]);
 const _filesystemWithModeOverride = GLib.build_filenamev([_overrides, _filesystemWithMode]);
 const _resetModeOverride = GLib.build_filenamev([_overrides, _resetModeId]);
 const _conditionalOverride = GLib.build_filenamev([_overrides, _conditionalAppId]);
@@ -88,6 +90,9 @@ const _globalWithGlobalOverride = GLib.build_filenamev([_global, 'overrides', _g
 
 const _sessionGroup = 'Session Bus Policy';
 const _key = 'filesystems';
+const _usbGroup = 'USB Devices';
+const _usbKey = 'enumerable-devices';
+const _usbHiddenKey = 'hidden-devices';
 
 const _flatpakConfig = GLib.build_filenamev(['..', 'tests', 'content']);
 
@@ -134,6 +139,7 @@ describe('Model', function() {
         GLib.unlink(_unsupportedOverride);
         GLib.unlink(_environmentOverride);
         GLib.unlink(_busOverride);
+        GLib.unlink(_usbOverride);
         GLib.unlink(_filesystemWithModeOverride);
         GLib.unlink(_resetModeOverride);
         GLib.unlink(_conditionalOverride);
@@ -718,7 +724,7 @@ describe('Model', function() {
 
         const total = permissionsDefault.getAll().filter(p => p.supported).length;
 
-        expect(total).toEqual(_totalPermissions - 11);
+        expect(total).toEqual(_totalPermissions - 13);
     });
 
     it('handles missing .flatpak-info', function() {
@@ -1492,5 +1498,66 @@ describe('Model', function() {
         permissionsDefault.appId = _malformedAppId;
 
         expect(permissionsDefault.emit.calls.first().args).toEqual(['failed']);
+    });
+
+    it('loads USB devices', function() {
+        permissionsDefault.appId = _usbAppId;
+        expect(permissionsDefault.usb).toEqual('vnd:0123');
+        expect(permissionsDefault.usb_hidden).toEqual('vnd:0408+dev:5348');
+
+        GLib.setenv('FLATPAK_USER_DIR', _user, true);
+        permissionsDefault.appId = _usbAppId;
+        expect(permissionsDefault.usb).toEqual('vnd:0123;vnd:0456');
+        expect(permissionsDefault.usb_hidden).toContain('vnd:0789');
+
+        GLib.setenv('FLATPAK_USER_DIR', _global, true);
+        permissionsDefault.appId = _usbAppId;
+        expect(permissionsDefault.usb).toEqual('vnd:0123;vnd:0567');
+
+        GLib.setenv('FLATPAK_USER_DIR', _statuses, true);
+        permissionsDefault.appId = _usbAppId;
+        expect(permissionsDefault.usb).toEqual('vnd:0123;vnd:0456;vnd:0789');
+        expect(permissionsDefault.usb_status).toEqual('original;global;user');
+        expect(permissionsDefault.usb_hidden).toEqual('vnd:0408+dev:5348;vnd:0111');
+        expect(permissionsDefault.usb_hidden_status).toEqual('original;user');
+    });
+
+    it('adds USB devices', function(done) {
+        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
+        permissionsDefault.appId = _usbAppId;
+
+        expect(permissionsDefault.usb).toEqual('vnd:0123');
+        expect(permissionsDefault.usb_hidden).toEqual('vnd:0408+dev:5348');
+
+        permissionsDefault.set_property('usb', 'vnd:0123;vnd:0456');
+        permissionsDefault.set_property('usb-hidden', 'vnd:0408+dev:5348;vnd:0999');
+
+        GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
+            expect(has(_usbOverride, _usbGroup, _usbKey, 'vnd:0456')).toBe(true);
+            expect(has(_usbOverride, _usbGroup, _usbKey, 'vnd:0123')).toBe(false);
+            expect(has(_usbOverride, _usbGroup, _usbHiddenKey, 'vnd:0999')).toBe(true);
+            expect(has(_usbOverride, _usbGroup, _usbHiddenKey, 'vnd:0408+dev:5348')).toBe(false);
+            expect(hasInTotal(_usbOverride)).toEqual(2);
+            done();
+            return GLib.SOURCE_REMOVE;
+        });
+
+        update();
+    });
+
+    it('does not block original USB device when removed from allowed', function(done) {
+        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
+        permissionsDefault.appId = _usbAppId;
+        expect(permissionsDefault.usb).toEqual('vnd:0123');
+        permissionsDefault.set_property('usb', '');
+
+        GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
+            expect(GLib.access(_usbOverride, 0)).toEqual(-1);
+            permissionsDefault.appId = _usbAppId;
+            expect(permissionsDefault.usb).toContain('vnd:0123');
+            done();
+            return GLib.SOURCE_REMOVE;
+        });
+        update();
     });
 });

--- a/tests/src/testUsbRow.js
+++ b/tests/src/testUsbRow.js
@@ -1,0 +1,112 @@
+/* eslint max-len: */
+
+/* testUsbRow.js
+ *
+ * Copyright 2026 Malika Odeny Asman
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const {setup} = imports.utils;
+setup();
+
+const {FlatsealUsbRow, validity} = imports.widgets.usbRow;
+const {FlatsealOverrideStatus} = imports.models.overrideStatus;
+
+describe('FlatsealUsbRow', function() {
+    var row;
+
+    beforeEach(function() {
+        row = new FlatsealUsbRow();
+    });
+
+    it('starts empty', function() {
+        expect(row.text).toEqual('');
+    });
+
+    it('processes device correctly', function() {
+        const text = 'vnd:0123';
+        row.text = text;
+
+        expect(row.text).toEqual(text);
+    });
+
+    it('disables editing and remove for origin devices', function() {
+        row.status = FlatsealOverrideStatus.ORIGINAL;
+        expect(row.sensitive).toBe(false);
+    });
+
+    it('disables editing and remove for global devices', function() {
+        row.status = FlatsealOverrideStatus.GLOBAL;
+        expect(row.sensitive).toBe(false);
+    });
+
+    it('enables editing and remove for user devices', function() {
+        row.status = FlatsealOverrideStatus.USER;
+        expect(row.sensitive).toBe(true);
+    });
+
+    function _handles(description, device) {
+        it(`handles ${description}`, function() {
+            row.text = device;
+            const context = row.get_style_context();
+
+            expect(context.has_class(validity.VALID)).toBe(true);
+            expect(context.has_class(validity.NOTVALID)).toBe(false);
+        });
+    }
+
+    _handles('all devices', 'all');
+    _handles('vendor id', 'vnd:0123');
+    _handles('vendor id (uppercase hex)', 'vnd:ABCD');
+    _handles('vendor id (mixed hex)', 'vnd:aAbB');
+    _handles('class and subclass id', 'cls:ff:01');
+    _handles('class and subclass id (uppercase)', 'cls:AB:CD');
+    _handles('class and wildcard subclass', 'cls:ff:*');
+    _handles('vendor + device compound', 'vnd:0123+dev:4567');
+    _handles('vendor + class compound', 'vnd:0123+cls:ab:cd');
+    _handles('device before vendor compound', 'dev:4567+vnd:0123');
+    _handles('vendor + device + class compound', 'vnd:0123+dev:4567+cls:ff:01');
+
+    function _catches(description, device) {
+        it(`catches ${description}`, function() {
+            row.text = device;
+            const context = row.get_style_context();
+
+            expect(context.has_class(validity.VALID)).toBe(false);
+            expect(context.has_class(validity.NOTVALID)).toBe(true);
+        });
+    }
+
+    _catches('empty string', '');
+    _catches('negated all devices', '!all');
+    _catches('negated vendor id', '!vnd:0123');
+    _catches('negated device id', '!dev:1234');
+    _catches('negated class id', '!cls:ff:01');
+    _catches('negated vendor + device compound', '!vnd:0123+dev:4567');
+    _catches('standalone device id', 'dev:1234');
+    _catches('device + class without vendor', 'dev:0123+cls:ff:01');
+    _catches('vendor id with 3 hex digits', 'vnd:012');
+    _catches('vendor id with 5 hex digits', 'vnd:01234');
+    _catches('class id without subclass', 'cls:ff');
+    _catches('class id with 1 hex digit', 'cls:f');
+    _catches('class id with 3 hex digits in class part', 'cls:fff:01');
+    _catches('class id with 4 hex digits', 'cls:0123');
+    _catches('non-hex vendor id', 'vnd:XXXX');
+    _catches('unknown prefix', 'xyz:0123');
+    _catches('trailing plus in compound', 'vnd:0123+');
+    _catches('incomplete compound device', 'vnd:0123+dev:');
+    _catches('partial vendor id', 'vnd:');
+    _catches('double negation', '!!vnd:0123');
+});


### PR DESCRIPTION
Expose the portal's enumerable-devices (`--usb`) and hidden-devices (`--nousb`) overrides as two independent properties, `usb` and `usb-hidden`. Each tracks its own originals, globals, and overrides, and neither depends on the other's state when processing changes, allowing a device to exist in both the allowed and blocked lists without either property modifying the other.

Add a USB permissions row with a USB-specific validation regex, a status icon indicating whether an entry is original, global, or user-added, and a remove button that is only enabled for user-added entries.

Handle empty-string values safely when loading and updating USB portal permissions.

Extend test coverage for model loading and saving, widget validation, and remove-button sensitivity.
