### PR TITLE
models: Fix crash from invalid release timestamps

### DIFF
--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -352,7 +352,8 @@ var FlatpakApplicationsModel = GObject.registerClass({
         if (release.get_timestamp() !== null) {
             const ts = release.get_timestamp();
             const date = new Date(ts * 1000);
-            appdata.date = date.toISOString().substring(0, 10);
+            if (!isNaN(date))
+                appdata.date = date.toISOString().substring(0, 10);
         }
 
         return appdata;

--- a/tests/content/system/flatpak/app/com.test.InvalidTimestamp/current/active/files/share/metainfo/com.test.InvalidTimestamp.metainfo.xml
+++ b/tests/content/system/flatpak/app/com.test.InvalidTimestamp/current/active/files/share/metainfo/com.test.InvalidTimestamp.metainfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>com.test.InvalidTimestamp</id>
+  <name>Invalid Timestamp</name>
+  <Author>Yooh</Author>
+  <summary>minimal test application</summary>
+  <releases>
+    <release version="0.0.1" timestamp="999999999999999"/>
+  </releases>
+</component>

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -57,6 +57,7 @@ const _globalRestoredAppId = 'com.test.GlobalRestored';
 const _statusesAppId = 'com.test.Statuses';
 const _malformedAppId = 'com.test.Malformed';
 const _conditionalAppId = 'com.test.Conditional';
+const _invalidTimestampAppId = 'com.test.InvalidTimestamp';
 
 const _flatpakInfo = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info']);
 const _flatpakInfoOld = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info.old']);
@@ -171,6 +172,16 @@ describe('Model', function() {
 
         const appIds = applicationsDefault.getAll().map(a => a.appId);
         expect(appIds).not.toContain(_baseAppId);
+    });
+
+    it('does not crash on an out-of-range release timestamp', function() {
+        expect(() => applicationsDefault.getAppDataForAppId(_invalidTimestampAppId)).not.toThrow();
+
+        const appdata = applicationsDefault.getAppDataForAppId(_invalidTimestampAppId);
+        expect(appdata.date).toEqual(_('Unknown'));
+
+        const appIds = applicationsDefault.getAll().map(a => a.appId);
+        expect(appIds).toContain(_invalidTimestampAppId);
     });
 
     it('loads permissions', function() {


### PR DESCRIPTION
An application's metainfo could contain a release timestamp too large
or too small to represent as a valid date. Formatting such a date could
throw an uncaught error during startup and prevent Flatseal from launching.

Check the date before formatting it and fall back to the existing default
when the timestamp is invalid.