### PR TITLE
Add conditional permission support

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -258,4 +258,4 @@ globals:
   beforeAll: false
   afterAll: false
 parserOptions:
-  ecmaVersion: 2018
+  ecmaVersion: 2020

--- a/src/com.github.tchx84.Flatseal.data.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.data.gresource.xml
@@ -6,6 +6,7 @@
     <file>widgets/appInfoViewer.ui</file>
     <file>widgets/applicationRow.ui</file>
     <file>widgets/busNameRow.ui</file>
+    <file>widgets/conditionalStatusIcon.ui</file>
     <file>widgets/docsViewer.ui</file>
     <file>widgets/globalInfoViewer.ui</file>
     <file>widgets/globalRow.ui</file>

--- a/src/com.github.tchx84.Flatseal.src.gresource.xml
+++ b/src/com.github.tchx84.Flatseal.src.gresource.xml
@@ -7,6 +7,7 @@
     <file>widgets/appInfoViewer.js</file>
     <file>widgets/applicationRow.js</file>
     <file>widgets/busNameRow.js</file>
+    <file>widgets/conditionalStatusIcon.js</file>
     <file>widgets/detailsButton.js</file>
     <file>widgets/docsViewer.js</file>
     <file>widgets/globalInfoViewer.js</file>

--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -204,27 +204,6 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     .replace(/;+$/, '')
                     .split(';');
 
-                /* Group entries by the plain option name they belong to, so a
-                 * conditional's full original text can be preserved
-                 * on write-back. */
-                const optionGroups = new Map();
-
-                values.forEach(option => {
-                    let plainOption = option.replace('!', '');
-
-                    if (option.startsWith(CONDITIONAL_PREFIX)) {
-                        const parts = option.slice(CONDITIONAL_PREFIX.length).split(':');
-
-                        if (parts.length >= 2)
-                            [plainOption] = parts;
-                    }
-
-                    if (!optionGroups.has(plainOption))
-                        optionGroups.set(plainOption, []);
-
-                    optionGroups.get(plainOption).push(option);
-                });
-
                 values.forEach(option => {
                     let isConditional = false;
                     let bareOption = option;
@@ -232,6 +211,10 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     if (option.startsWith(CONDITIONAL_PREFIX)) {
                         const parts = option.slice(CONDITIONAL_PREFIX.length).split(':');
 
+                        /* A valid conditional has both an option and a
+                         * condition after "if:". Ignore incomplete
+                         * entries instead of treating them as
+                         * conditionals. */
                         if (parts.length >= 2) {
                             isConditional = true;
                             [bareOption] = parts;
@@ -243,19 +226,22 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     if (model === null)
                         model = this.constructor._find(`${group}_${key}`);
 
-                    if (model === null && overrides && !global && !isConditional)
+                    if (model === null && overrides && !global)
                         model = MODELS.unsupported;
 
-                    /* Ignore conditional entries that don't match a
-                     * supported model. */
+                    /* Only the four models in CONDITIONAL_MODELS are
+                     * recognized to support conditionals. A conditional
+                     * entry for anything else is skipped entirely here:
+                     * not loaded into any model, not shown in the UI,
+                     * and never tracked, so nothing is ever written
+                     * back for it either. This avoids guessing at
+                     * syntax that is not supported and risking
+                     * corruption of the override file. */
                     if (isConditional && CONDITIONAL_MODELS.includes(model)) {
-                        const plainOption = bareOption.replace('!', '');
-                        const fullGroup = optionGroups.get(plainOption).join(';');
-
                         model?.loadFromKeyFile(group, key, bareOption, overrides, global);
-                        model?.markConditional(plainOption, option, fullGroup, overrides, global);
+                        model?.markConditional(bareOption, option);
                     } else if (!isConditional) {
-                        model?.loadFromKeyFile(group, key, option, overrides, global);
+                        model?.loadFromKeyFile(group, key, bareOption, overrides, global);
                     }
                 });
             });

--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -53,7 +53,12 @@ const MODELS = {
 };
 
 /* Models that support conditional permissions */
-const CONDITIONAL_MODELS = [MODELS.shared, MODELS.sockets, MODELS.devices, MODELS.features];
+const CONDITIONAL_MODELS = [
+    MODELS.shared,
+    MODELS.sockets,
+    MODELS.devices,
+    MODELS.features,
+];
 
 function generate_index() {
     const index = {};
@@ -216,17 +221,14 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     if (model === null && overrides && !global)
                         model = MODELS.unsupported;
 
-                    if (model === null)
-                        return;
-
                     /* Preserves the original conditional string for models
                      * that don't support conditionals, so the condition
                      * is not lost.*/
-                    if (isConditional && model !== MODELS.unsupported) {
-                        model.loadFromKeyFile(group, key, bareOption, overrides, global);
-                        model.markConditional(bareOption, option);
+                    if (isConditional && CONDITIONAL_MODELS.includes(model)) {
+                        model?.loadFromKeyFile(group, key, bareOption, overrides, global);
+                        model?.markConditional(bareOption, option);
                     } else {
-                        model.loadFromKeyFile(group, key, option, overrides, global);
+                        model?.loadFromKeyFile(group, key, option, overrides, global);
                     }
                 });
             });

--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -204,6 +204,27 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     .replace(/;+$/, '')
                     .split(';');
 
+                /* Group entries by the plain option name they belong to, so a
+                 * conditional's full original text can be preserved
+                 * on write-back. */
+                const optionGroups = new Map();
+
+                values.forEach(option => {
+                    let plainOption = option.replace('!', '');
+
+                    if (option.startsWith(CONDITIONAL_PREFIX)) {
+                        const parts = option.slice(CONDITIONAL_PREFIX.length).split(':');
+
+                        if (parts.length >= 2)
+                            [plainOption] = parts;
+                    }
+
+                    if (!optionGroups.has(plainOption))
+                        optionGroups.set(plainOption, []);
+
+                    optionGroups.get(plainOption).push(option);
+                });
+
                 values.forEach(option => {
                     let isConditional = false;
                     let bareOption = option;
@@ -228,8 +249,11 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     /* Ignore conditional entries that don't match a
                      * supported model. */
                     if (isConditional && CONDITIONAL_MODELS.includes(model)) {
+                        const plainOption = bareOption.replace('!', '');
+                        const fullGroup = optionGroups.get(plainOption).join(';');
+
                         model?.loadFromKeyFile(group, key, bareOption, overrides, global);
-                        model?.markConditional(bareOption, option);
+                        model?.markConditional(plainOption, option, fullGroup, overrides, global);
                     } else if (!isConditional) {
                         model?.loadFromKeyFile(group, key, option, overrides, global);
                     }

--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -52,6 +52,9 @@ const MODELS = {
     unsupported: new FlatpakUnsupportedModel(),
 };
 
+/* Models that support conditional permissions */
+const CONDITIONAL_MODELS = [MODELS.shared, MODELS.sockets, MODELS.devices, MODELS.features];
+
 function generate_index() {
     const index = {};
 
@@ -197,24 +200,15 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     .split(';');
 
                 values.forEach(option => {
+                    let isConditional = false;
+                    let bareOption = option;
+
                     if (option.startsWith(CONDITIONAL_PREFIX)) {
-                        /* Record the conditional request as a real
-                         * permission, without letting it fall into the
-                         * unsupported bucket. */
-                        const [conditionalOption] = option.slice(CONDITIONAL_PREFIX.length).split(':');
-                        let conditionalModel = this.constructor._find(`${group}_${key}_${conditionalOption}`);
-
-                        if (conditionalModel === null)
-                            conditionalModel = this.constructor._find(`${group}_${key}`);
-
-                        if (conditionalModel !== null) {
-                            conditionalModel.loadFromKeyFile(group, key, conditionalOption, overrides, global);
-                            conditionalModel.markConditional(conditionalOption, option);
-                        }
-                        return;
+                        isConditional = true;
+                        [bareOption] = option.slice(CONDITIONAL_PREFIX.length).split(':');
                     }
 
-                    model = this.constructor._find(`${group}_${key}_${option.replace('!', '')}`);
+                    model = this.constructor._find(`${group}_${key}_${bareOption.replace('!', '')}`);
 
                     if (model === null)
                         model = this.constructor._find(`${group}_${key}`);
@@ -222,8 +216,18 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     if (model === null && overrides && !global)
                         model = MODELS.unsupported;
 
-                    if (model !== null)
+                    if (model === null)
+                        return;
+
+                    /* Preserves the original conditional string for models
+                     * that don't support conditionals, so the condition
+                     * is not lost.*/
+                    if (isConditional && model !== MODELS.unsupported) {
+                        model.loadFromKeyFile(group, key, bareOption, overrides, global);
+                        model.markConditional(bareOption, option);
+                    } else {
                         model.loadFromKeyFile(group, key, option, overrides, global);
+                    }
                 });
             });
         });
@@ -287,8 +291,7 @@ var FlatpakPermissionsModel = GObject.registerClass({
         GObject.signal_handler_block(this, this._notifyHandlerId);
 
         Object.values(MODELS).forEach(model => model.updateStatusProperty(this));
-        [MODELS.shared, MODELS.sockets, MODELS.devices, MODELS.features]
-            .forEach(model => model.updateConditionalProperty(this));
+        CONDITIONAL_MODELS.forEach(model => model.updateConditionalProperty(this));
 
         GObject.signal_handler_unblock(this, this._notifyHandlerId);
     }

--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -209,8 +209,12 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     let bareOption = option;
 
                     if (option.startsWith(CONDITIONAL_PREFIX)) {
-                        isConditional = true;
-                        [bareOption] = option.slice(CONDITIONAL_PREFIX.length).split(':');
+                        const parts = option.slice(CONDITIONAL_PREFIX.length).split(':');
+
+                        if (parts.length >= 2) {
+                            isConditional = true;
+                            [bareOption] = parts;
+                        }
                     }
 
                     model = this.constructor._find(`${group}_${key}_${bareOption.replace('!', '')}`);
@@ -218,16 +222,15 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     if (model === null)
                         model = this.constructor._find(`${group}_${key}`);
 
-                    if (model === null && overrides && !global)
+                    if (model === null && overrides && !global && !isConditional)
                         model = MODELS.unsupported;
 
-                    /* Preserves the original conditional string for models
-                     * that don't support conditionals, so the condition
-                     * is not lost.*/
+                    /* Ignore conditional entries that don't match a
+                     * supported model. */
                     if (isConditional && CONDITIONAL_MODELS.includes(model)) {
                         model?.loadFromKeyFile(group, key, bareOption, overrides, global);
                         model?.markConditional(bareOption, option);
-                    } else {
+                    } else if (!isConditional) {
                         model?.loadFromKeyFile(group, key, option, overrides, global);
                     }
                 });

--- a/src/models/permissions.js
+++ b/src/models/permissions.js
@@ -102,6 +102,11 @@ function generate() {
             const statusProperty = `${property}-status`;
             properties[statusProperty] = GObject.ParamSpec.string(
                 statusProperty, statusProperty, statusProperty, FLAGS, FlatsealOverrideStatus.ORIGINAL);
+
+            /* conditional requests */
+            const conditionalProperty = `${property}-conditional`;
+            properties[conditionalProperty] = GObject.ParamSpec.string(
+                conditionalProperty, conditionalProperty, conditionalProperty, FLAGS, '');
         });
     });
 
@@ -192,10 +197,22 @@ var FlatpakPermissionsModel = GObject.registerClass({
                     .split(';');
 
                 values.forEach(option => {
-                    /* Flatseal does not support conditionals, but skips them
-                     * to avoid corrupting the overrides file. */
-                    if (option.startsWith(CONDITIONAL_PREFIX))
+                    if (option.startsWith(CONDITIONAL_PREFIX)) {
+                        /* Record the conditional request as a real
+                         * permission, without letting it fall into the
+                         * unsupported bucket. */
+                        const [conditionalOption] = option.slice(CONDITIONAL_PREFIX.length).split(':');
+                        let conditionalModel = this.constructor._find(`${group}_${key}_${conditionalOption}`);
+
+                        if (conditionalModel === null)
+                            conditionalModel = this.constructor._find(`${group}_${key}`);
+
+                        if (conditionalModel !== null) {
+                            conditionalModel.loadFromKeyFile(group, key, conditionalOption, overrides, global);
+                            conditionalModel.markConditional(conditionalOption, option);
+                        }
                         return;
+                    }
 
                     model = this.constructor._find(`${group}_${key}_${option.replace('!', '')}`);
 
@@ -270,6 +287,8 @@ var FlatpakPermissionsModel = GObject.registerClass({
         GObject.signal_handler_block(this, this._notifyHandlerId);
 
         Object.values(MODELS).forEach(model => model.updateStatusProperty(this));
+        [MODELS.shared, MODELS.sockets, MODELS.devices, MODELS.features]
+            .forEach(model => model.updateConditionalProperty(this));
 
         GObject.signal_handler_unblock(this, this._notifyHandlerId);
     }
@@ -394,6 +413,7 @@ var FlatpakPermissionsModel = GObject.registerClass({
                 entry['groupStyle'] = model.constructor.getStyle();
                 entry['groupDescription'] = model.constructor.getDescription();
                 entry['statusProperty'] = `${property}-status`;
+                entry['conditionalProperty'] = `${property}-conditional`;
                 entry['serializeFunc'] = model.constructor.serialize;
                 entry['deserializeFunc'] = model.constructor.deserialize;
 

--- a/src/models/shared.js
+++ b/src/models/shared.js
@@ -150,6 +150,23 @@ var FlatpakSharedModel = GObject.registerClass({
         });
     }
 
+    /* Flatpak drops a conditional if a bare grant for the same
+     * option is applied afterward, so this being set doesn't
+     * guarantee the permission is actually granted at runtime. */
+    markConditional(option, rawValue) {
+        this._conditionals.set(option, rawValue);
+    }
+
+    updateConditionalProperty(proxy) {
+        Object.entries(this.getPermissions()).forEach(([property, permission]) => {
+            const {option} = permission;
+            const conditionalProperty = `${property}-conditional`;
+            const value = this._conditionals.get(option) || '';
+
+            proxy.set_property(conditionalProperty, value);
+        });
+    }
+
     updateProxyProperty(proxy) {
         const originals = [...this._originals]
             .filter(o => !this.constructor._isOverriden(this._globals, o))
@@ -190,6 +207,10 @@ var FlatpakSharedModel = GObject.registerClass({
         const group = this.constructor.getGroup();
         const key = this.constructor.getKey();
 
+        /* This only writes from _overrides (the on/off state), it does
+         * not write out anything from _conditionals. Saving can
+         * therefore drop an existing conditional entry from the
+         * override file. Write-back isn't implemented yet. */
         this._overrides.forEach(value => {
             let _value = value;
 
@@ -208,5 +229,6 @@ var FlatpakSharedModel = GObject.registerClass({
         this._overrides = new Set();
         this._globals = new Set();
         this._originals = new Set();
+        this._conditionals = new Map();
     }
 });

--- a/src/models/shared.js
+++ b/src/models/shared.js
@@ -150,18 +150,21 @@ var FlatpakSharedModel = GObject.registerClass({
         });
     }
 
-    /* Flatpak drops a conditional if a bare grant for the same
-     * option is applied afterward, so this being set doesn't
-     * guarantee the permission is actually granted at runtime. */
-    markConditional(option, rawValue) {
-        this._conditionals.set(option, rawValue);
+    /* Only write back the per-app overrides.
+     * Metadata should remain unchanged, and global conditionals
+     * are already stored in their own file. */
+    markConditional(option, rawValue, fullGroup, overrides, global) {
+        const fromOverride = Boolean(overrides) && !global;
+
+        this._conditionals.set(option, {value: rawValue, group: fullGroup, fromOverride});
     }
 
     updateConditionalProperty(proxy) {
         Object.entries(this.getPermissions()).forEach(([property, permission]) => {
             const {option} = permission;
             const conditionalProperty = `${property}-conditional`;
-            const value = this._conditionals.get(option) || '';
+            const conditional = this._conditionals.get(option);
+            const value = conditional ? conditional.value : '';
 
             proxy.set_property(conditionalProperty, value);
         });
@@ -203,25 +206,92 @@ var FlatpakSharedModel = GObject.registerClass({
         set.add(value);
     }
 
+    static _writeValue(keyFile, group, key, value) {
+        let _value = value;
+
+        try {
+            const existing = keyFile.get_value(group, key);
+            _value = `${value};${existing}`;
+        } catch (err) {
+            _value = `${value}`;
+        }
+
+        keyFile.set_value(group, key, _value);
+    }
+
+    /* Resolve the conditional's bare entries independently of the "if:"
+     * entry. For example, "all;if:all:!has-input-device" resolves to
+     * true for "all". */
+    static _impliedValue(fullGroup, option) {
+        const entries = fullGroup.split(';');
+        let value = false;
+
+        if (entries.includes(option))
+            value = true;
+        if (entries.includes(`!${option}`))
+            value = false;
+
+        return value;
+    }
+
+    /* Get the current value for an option, using the same logic as
+     * updateProxyProperty. */
+    _currentValue(option) {
+        const originals = [...this._originals]
+            .filter(o => !this.constructor._isOverriden(this._globals, o))
+            .filter(o => !this.constructor._isOverriden(this._overrides, o));
+
+        const globals = [...this._globals]
+            .filter(g => !this.constructor._isOverriden(this._overrides, g));
+
+        const permissions = new Set([...originals, ...globals, ...this._overrides]);
+
+        let value = this.constructor.getDefault();
+
+        if (permissions.has(option))
+            value = true;
+        if (permissions.has(`!${option}`))
+            value = false;
+
+        return value;
+    }
+
     saveToKeyFile(keyFile) {
         const group = this.constructor.getGroup();
         const key = this.constructor.getKey();
 
-        /* This only writes from _overrides (the on/off state), it does
-         * not write out anything from _conditionals. Saving can
-         * therefore drop an existing conditional entry from the
-         * override file. Write-back isn't implemented yet. */
-        this._overrides.forEach(value => {
-            let _value = value;
+        /* Preserve a per-app conditional exactly as it was found, so an
+         * unrelated save doesn't silently drop it. But if the option's
+         * current value no longer matches what the conditional's own
+         * entries imply, the user has explicitly changed that specific
+         * permission since it was loaded, so let their plain toggle
+         * win instead, matching how a fresh bare grant clears a
+         * conditional in real Flatpak. Once dropped this way, forget
+         * it for good */
+        const preserved = new Set();
 
-            try {
-                const existing = keyFile.get_value(group, key);
-                _value = `${value};${existing}`;
-            } catch (err) {
-                _value = `${value}`;
+        this._conditionals.forEach((conditional, option) => {
+            if (!conditional.fromOverride)
+                return;
+
+            const impliedValue = this.constructor._impliedValue(conditional.group, option);
+
+            if (this._currentValue(option) !== impliedValue) {
+                this._conditionals.delete(option);
+                return;
             }
 
-            keyFile.set_value(group, key, _value);
+            preserved.add(option);
+            this.constructor._writeValue(keyFile, group, key, conditional.group);
+        });
+
+        this._overrides.forEach(value => {
+            const option = value.replace('!', '');
+
+            if (preserved.has(option))
+                return;
+
+            this.constructor._writeValue(keyFile, group, key, value);
         });
     }
 

--- a/src/models/shared.js
+++ b/src/models/shared.js
@@ -150,21 +150,18 @@ var FlatpakSharedModel = GObject.registerClass({
         });
     }
 
-    /* Only write back the per-app overrides.
-     * Metadata should remain unchanged, and global conditionals
-     * are already stored in their own file. */
-    markConditional(option, rawValue, fullGroup, overrides, global) {
-        const fromOverride = Boolean(overrides) && !global;
-
-        this._conditionals.set(option, {value: rawValue, group: fullGroup, fromOverride});
+    /* Flatpak drops a conditional if a bare grant for the same
+     * option is applied afterward, so this being set doesn't
+     * guarantee the permission is actually granted at runtime. */
+    markConditional(option, rawValue) {
+        this._conditionals.set(option, rawValue);
     }
 
     updateConditionalProperty(proxy) {
         Object.entries(this.getPermissions()).forEach(([property, permission]) => {
             const {option} = permission;
             const conditionalProperty = `${property}-conditional`;
-            const conditional = this._conditionals.get(option);
-            const value = conditional ? conditional.value : '';
+            const value = this._conditionals.get(option) || '';
 
             proxy.set_property(conditionalProperty, value);
         });
@@ -206,92 +203,25 @@ var FlatpakSharedModel = GObject.registerClass({
         set.add(value);
     }
 
-    static _writeValue(keyFile, group, key, value) {
-        let _value = value;
-
-        try {
-            const existing = keyFile.get_value(group, key);
-            _value = `${value};${existing}`;
-        } catch (err) {
-            _value = `${value}`;
-        }
-
-        keyFile.set_value(group, key, _value);
-    }
-
-    /* Resolve the conditional's bare entries independently of the "if:"
-     * entry. For example, "all;if:all:!has-input-device" resolves to
-     * true for "all". */
-    static _impliedValue(fullGroup, option) {
-        const entries = fullGroup.split(';');
-        let value = false;
-
-        if (entries.includes(option))
-            value = true;
-        if (entries.includes(`!${option}`))
-            value = false;
-
-        return value;
-    }
-
-    /* Get the current value for an option, using the same logic as
-     * updateProxyProperty. */
-    _currentValue(option) {
-        const originals = [...this._originals]
-            .filter(o => !this.constructor._isOverriden(this._globals, o))
-            .filter(o => !this.constructor._isOverriden(this._overrides, o));
-
-        const globals = [...this._globals]
-            .filter(g => !this.constructor._isOverriden(this._overrides, g));
-
-        const permissions = new Set([...originals, ...globals, ...this._overrides]);
-
-        let value = this.constructor.getDefault();
-
-        if (permissions.has(option))
-            value = true;
-        if (permissions.has(`!${option}`))
-            value = false;
-
-        return value;
-    }
-
     saveToKeyFile(keyFile) {
         const group = this.constructor.getGroup();
         const key = this.constructor.getKey();
 
-        /* Preserve a per-app conditional exactly as it was found, so an
-         * unrelated save doesn't silently drop it. But if the option's
-         * current value no longer matches what the conditional's own
-         * entries imply, the user has explicitly changed that specific
-         * permission since it was loaded, so let their plain toggle
-         * win instead, matching how a fresh bare grant clears a
-         * conditional in real Flatpak. Once dropped this way, forget
-         * it for good */
-        const preserved = new Set();
+        /* This only writes from _overrides (the on/off state), it does
+         * not write out anything from _conditionals. Saving can
+         * therefore drop an existing conditional entry from the
+         * override file. Write-back isn't implemented yet. */
+        this._overrides.forEach(value => {
+            let _value = value;
 
-        this._conditionals.forEach((conditional, option) => {
-            if (!conditional.fromOverride)
-                return;
-
-            const impliedValue = this.constructor._impliedValue(conditional.group, option);
-
-            if (this._currentValue(option) !== impliedValue) {
-                this._conditionals.delete(option);
-                return;
+            try {
+                const existing = keyFile.get_value(group, key);
+                _value = `${value};${existing}`;
+            } catch (err) {
+                _value = `${value}`;
             }
 
-            preserved.add(option);
-            this.constructor._writeValue(keyFile, group, key, conditional.group);
-        });
-
-        this._overrides.forEach(value => {
-            const option = value.replace('!', '');
-
-            if (preserved.has(option))
-                return;
-
-            this.constructor._writeValue(keyFile, group, key, value);
+            keyFile.set_value(group, key, _value);
         });
     }
 

--- a/src/style.css
+++ b/src/style.css
@@ -20,6 +20,14 @@ row .status.user {
 row .status.global {
     color: @insensitive_fg_color;
 }
+row .conditional {
+    padding: 8px;
+    background-color: transparent;
+    background-image: -gtk-icontheme("dialog-question-symbolic");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 16px;
+}
 
 row .content .bus .info,
 row .content .variable .info,

--- a/src/widgets/conditionalStatusIcon.js
+++ b/src/widgets/conditionalStatusIcon.js
@@ -1,0 +1,65 @@
+/* exported FlatsealConditionalStatusIcon */
+
+/* conditionalStatusIcon.js
+ *
+ * Copyright 2026 Malika Odeny Asman
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const {GObject, Gtk} = imports.gi;
+
+
+var FlatsealConditionalStatusIcon = GObject.registerClass({
+    GTypeName: 'FlatsealConditionalStatusIcon',
+    Template: 'resource:///com/github/tchx84/Flatseal/widgets/conditionalStatusIcon.ui',
+    Properties: {
+        value: GObject.ParamSpec.string(
+            'value',
+            'value',
+            'value',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            '',
+        ),
+    },
+}, class FlatsealConditionalStatusIcon extends Gtk.Image {
+    _init() {
+        super._init({});
+        this._value = '';
+    }
+
+    set value(value) {
+        if (this._value === value)
+            return;
+
+        this._value = value;
+
+        if (value === '') {
+            this.set_tooltip_text('');
+            this.visible = false;
+            return;
+        }
+
+        const condition = value
+            .split(':')
+            .slice(2)
+            .join(':');
+        this.set_tooltip_text(_('Only granted if: %s').format(condition));
+        this.visible = true;
+    }
+
+    get value() {
+        return this._value;
+    }
+});

--- a/src/widgets/conditionalStatusIcon.ui
+++ b/src/widgets/conditionalStatusIcon.ui
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="FlatsealConditionalStatusIcon" parent="GtkImage">
+    <style>
+      <class name="conditional"/>
+    </style>
+  </template>
+</interface>

--- a/src/widgets/permissionSwitchRow.js
+++ b/src/widgets/permissionSwitchRow.js
@@ -3,6 +3,7 @@
 /* permissionSwitchRow.js
  *
  * Copyright 2020 Martin Abente Lahaye
+ * Copyright 2026 Malika Odeny Asman
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +21,7 @@
 
 const {GObject, Adw} = imports.gi;
 const {FlatsealOverrideStatusIcon} = imports.widgets.overrideStatusIcon;
+const {FlatsealConditionalStatusIcon} = imports.widgets.conditionalStatusIcon;
 
 
 var FlatsealPermissionSwitchRow = GObject.registerClass({
@@ -36,6 +38,9 @@ var FlatsealPermissionSwitchRow = GObject.registerClass({
 
         this._statusIcon = new FlatsealOverrideStatusIcon();
         this._statusBox.append(this._statusIcon);
+
+        this._conditionalIcon = new FlatsealConditionalStatusIcon();
+        this._statusBox.append(this._conditionalIcon);
     }
 
     _update() {
@@ -51,6 +56,10 @@ var FlatsealPermissionSwitchRow = GObject.registerClass({
 
     get status() {
         return this._statusIcon;
+    }
+
+    get conditional() {
+        return this._conditionalIcon;
     }
 
     get supported() {

--- a/src/widgets/window.js
+++ b/src/widgets/window.js
@@ -284,6 +284,11 @@ var FlatsealWindow = GObject.registerClass({
                 return;
 
             this._permissions.bind_property(p.statusProperty, row.status, 'status', _bindFlags);
+
+            if (!row.conditional)
+                return;
+
+            this._permissions.bind_property(p.conditionalProperty, row.conditional, 'value', _bindFlags);
         });
     }
 

--- a/tests/content/system/flatpak/app/com.test.Conditional/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.Conditional/current/active/metadata
@@ -5,4 +5,4 @@ sdk=org.gnome.Sdk/x86_64/master
 command=test
 
 [Context]
-sockets=x11;if:x11:!has-wayland;
+sockets=x11;if:x11:!has-wayland;if:wayland:true;

--- a/tests/content/user/flatpak/overrides/com.test.Unsupported
+++ b/tests/content/user/flatpak/overrides/com.test.Unsupported
@@ -1,3 +1,3 @@
 [Context]
 shared=unsupported
-unsupported=always;if:teleport:true
+unsupported=always;if:unsupported-permission:!has-unsupported-permission

--- a/tests/content/user/flatpak/overrides/com.test.Unsupported
+++ b/tests/content/user/flatpak/overrides/com.test.Unsupported
@@ -1,3 +1,3 @@
 [Context]
 shared=unsupported
-unsupported=always
+unsupported=always;if:teleport:true

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -597,11 +597,27 @@ describe('Model', function() {
             expect(has(_unsupportedOverride, 'Context', 'unsupported', 'always')).toBe(true);
             expect(has(_unsupportedOverride, 'Context', 'unsupported', 'undefined')).toBe(false);
             expect(has(_unsupportedOverride, 'Context', 'unsupported', 'null')).toBe(false);
-            expect(has(_unsupportedOverride, 'Context', 'unsupported', 'if:teleport:true')).toBe(true);
 
             expect(has(_unsupportedOverride, 'Context', 'shared', 'unsupported')).toBe(true);
             expect(has(_unsupportedOverride, 'Context', 'shared', 'undefined')).toBe(false);
             expect(has(_unsupportedOverride, 'Context', 'shared', 'null')).toBe(false);
+
+            done();
+            return GLib.SOURCE_REMOVE;
+        });
+
+        update();
+    });
+
+    it('ignores unsupported conditional permissions', function(done) {
+        GLib.setenv('FLATPAK_USER_DIR', _user, true);
+        permissionsDefault.appId = _unsupportedAppId;
+
+        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
+        permissionsDefault.set_property('filesystems-other', '');
+
+        GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
+            expect(has(_unsupportedOverride, 'Context', 'unsupported', 'if:teleport:true')).toBe(false);
 
             done();
             return GLib.SOURCE_REMOVE;

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -617,7 +617,9 @@ describe('Model', function() {
         permissionsDefault.set_property('filesystems-other', '');
 
         GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
-            expect(has(_unsupportedOverride, 'Context', 'unsupported', 'if:teleport:true')).toBe(false);
+            expect(has(
+                _unsupportedOverride, 'Context', 'unsupported',
+                'if:unsupported-permission:!has-unsupported-permission')).toBe(false);
 
             done();
             return GLib.SOURCE_REMOVE;
@@ -1512,29 +1514,6 @@ describe('Model', function() {
             expect(has(_conditionalOverride, group, 'sockets', 'if:x11:!has-wayland')).toBe(false);
             expect(has(_conditionalOverride, group, 'devices', 'if:all:!has-input-device')).toBe(false);
             expect(hasInTotal(_conditionalOverride)).toEqual(1);
-            done();
-            return GLib.SOURCE_REMOVE;
-        });
-
-        update();
-    });
-
-    it('preserves conditional permissions on unrelated save', function(done) {
-        GLib.setenv('FLATPAK_USER_DIR', _user, true);
-        permissionsDefault.appId = _conditionalAppId;
-
-        expect(permissionsDefault.devices_all).toBe(true);
-        expect(permissionsDefault.devices_dri).toBe(false);
-
-        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
-        permissionsDefault.set_property('devices-dri', true);
-
-        GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
-            const group = permissionsDefault.constructor.getGroupForProperty('devices-dri');
-            expect(has(_conditionalOverride, group, 'devices', 'dri')).toBe(true);
-            expect(has(_conditionalOverride, group, 'devices', 'all')).toBe(true);
-            expect(has(_conditionalOverride, group, 'devices', 'if:all:!has-input-device')).toBe(true);
-            expect(hasInTotal(_conditionalOverride)).toEqual(3);
             done();
             return GLib.SOURCE_REMOVE;
         });

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -597,6 +597,7 @@ describe('Model', function() {
             expect(has(_unsupportedOverride, 'Context', 'unsupported', 'always')).toBe(true);
             expect(has(_unsupportedOverride, 'Context', 'unsupported', 'undefined')).toBe(false);
             expect(has(_unsupportedOverride, 'Context', 'unsupported', 'null')).toBe(false);
+            expect(has(_unsupportedOverride, 'Context', 'unsupported', 'if:teleport:true')).toBe(true);
 
             expect(has(_unsupportedOverride, 'Context', 'shared', 'unsupported')).toBe(true);
             expect(has(_unsupportedOverride, 'Context', 'shared', 'undefined')).toBe(false);

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1519,6 +1519,29 @@ describe('Model', function() {
         update();
     });
 
+    it('preserves conditional permissions on unrelated save', function(done) {
+        GLib.setenv('FLATPAK_USER_DIR', _user, true);
+        permissionsDefault.appId = _conditionalAppId;
+
+        expect(permissionsDefault.devices_all).toBe(true);
+        expect(permissionsDefault.devices_dri).toBe(false);
+
+        GLib.setenv('FLATPAK_USER_DIR', _tmp, true);
+        permissionsDefault.set_property('devices-dri', true);
+
+        GLib.timeout_add(GLib.PRIORITY_HIGH, delay + 1, () => {
+            const group = permissionsDefault.constructor.getGroupForProperty('devices-dri');
+            expect(has(_conditionalOverride, group, 'devices', 'dri')).toBe(true);
+            expect(has(_conditionalOverride, group, 'devices', 'all')).toBe(true);
+            expect(has(_conditionalOverride, group, 'devices', 'if:all:!has-input-device')).toBe(true);
+            expect(hasInTotal(_conditionalOverride)).toEqual(3);
+            done();
+            return GLib.SOURCE_REMOVE;
+        });
+
+        update();
+    });
+
     it('handles malformed overrides', function() {
         spyOn(permissionsDefault, 'emit');
 

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -1467,6 +1467,17 @@ describe('Model', function() {
         expect(permissionsDefault.sockets_x11).toBe(true);
     });
 
+    it('marks conditional permissions', function() {
+        GLib.setenv('FLATPAK_USER_DIR', _user, true);
+        permissionsDefault.appId = _conditionalAppId;
+
+        expect(permissionsDefault.sockets_x11_conditional).toBe('if:x11:!has-wayland');
+        expect(permissionsDefault.devices_all_conditional).toBe('if:all:!has-input-device');
+
+        expect(permissionsDefault.sockets_wayland).toBe(true);
+        expect(permissionsDefault.sockets_wayland_conditional).toBe('if:wayland:true');
+    });
+
     it('does not write conditional permissions back', function(done) {
         GLib.setenv('FLATPAK_USER_DIR', _user, true);
         permissionsDefault.appId = _conditionalAppId;


### PR DESCRIPTION
Previously, conditional permission entries (if:...) were discarded
entirely while parsing, to avoid treating them as unsupported and
corrupting the overrides file.

This now loads the underlying permission through the normal path,
the same as any other option, and separately records the raw
condition. A new status icon marks a permission row as conditional,
with a tooltip stating the condition it depends on.

**Limitations**
Flatpak drops a conditional permission if a bare grant for the same 
permission is applied afterward, so the switch showing "on" doesn’t 
always mean the permission is actually granted at runtime. 
This is Flatpak’s behaviour and not something Flatseal controls.

 `saveToKeyFile` right now only writes from the `overrides` Set (the on/off state)
 and doesn’t look at the conditionals map. So saving can drop an existing 
`conditional` entry from the override file. Write-back is not implemented yet

