### PR TITLE
models: Fix crash from unreadable or malformed installation configs

### DIFF
--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -122,7 +122,13 @@ var FlatpakApplicationsModel = GObject.registerClass({
         const installations = [];
 
         const keyFile = new GLib.KeyFile();
-        keyFile.load_from_file(path, GLib.KeyFileFlags.NONE);
+
+        try {
+            keyFile.load_from_file(path, GLib.KeyFileFlags.NONE);
+        } catch (err) {
+            logError(err, `Could not load custom installation config ${path}`);
+            return installations;
+        }
 
         const [groups] = keyFile.get_groups();
         groups.forEach(group => {

--- a/tests/content/brokenInstallations/installations.d/broken.conf
+++ b/tests/content/brokenInstallations/installations.d/broken.conf
@@ -1,0 +1,1 @@
+this is not a valid keyfile at all {{{ .,'?

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -95,6 +95,7 @@ const _usbKey = 'enumerable-devices';
 const _usbHiddenKey = 'hidden-devices';
 
 const _flatpakConfig = GLib.build_filenamev(['..', 'tests', 'content']);
+const _customInstallationConfig = GLib.build_filenamev(['..', 'tests', 'content', 'brokenInstallations']);
 
 
 describe('Model', function() {
@@ -755,6 +756,18 @@ describe('Model', function() {
 
         expect(permissionsDefault.shared_network).toBe(false);
         expect(permissionsDefault.shared_ipc).toBe(true);
+    });
+
+    it('does not crash when a custom installation config is malformed', function() {
+        GLib.setenv('FLATPAK_CONFIG_DIR', _customInstallationConfig, true);
+
+        expect(() => applicationsDefault.reload()).not.toThrow();
+
+        const appIds = applicationsDefault.getAll().map(a => a.appId);
+        expect(appIds).toContain(_basicAppId);
+
+        GLib.setenv('FLATPAK_CONFIG_DIR', _flatpakConfig, true);
+        applicationsDefault.reload();
     });
 
     it('add new environment variable', function(done) {


### PR DESCRIPTION
Flatseal reads config files under `installations.d/` to discover extra
Flatpak installation locations (e.g. an SD card). Parsing one of
those files had no error handling, if the file was unreadable or
contained invalid syntax, the exception went uncaught and aborted
Flatseal's startup, before any window opened. No crash dialog, no
visible error, the process just stayed running with nothing shown.

I reproduced it locally both ways (permission-denied file and a
syntactically invalid one) against a real build. Both failed
identically before this fix, and both are handled gracefully after
it.
