### PR TITLE
models: Fix crashes caused by malformed or unreadable data

### DIFF
--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -350,9 +350,9 @@ var FlatpakApplicationsModel = GObject.registerClass({
             appdata.version = `${release.get_version()}`;
 
         if (release.get_timestamp() !== null) {
-            const ts = release.get_timestamp();
-            const date = new Date(ts * 1000);
-            appdata.date = date.toISOString().substring(0, 10);
+            const date = GLib.DateTime.new_from_unix_utc(release.get_timestamp());
+            if (date !== null)
+                appdata.date = date.format('%Y-%m-%d');
         }
 
         return appdata;

--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -122,7 +122,13 @@ var FlatpakApplicationsModel = GObject.registerClass({
         const installations = [];
 
         const keyFile = new GLib.KeyFile();
-        keyFile.load_from_file(path, GLib.KeyFileFlags.NONE);
+
+        try {
+            keyFile.load_from_file(path, GLib.KeyFileFlags.NONE);
+        } catch (err) {
+            logError(err, `Could not load custom installation config ${path}`);
+            return installations;
+        }
 
         const [groups] = keyFile.get_groups();
         groups.forEach(group => {

--- a/tests/content/brokenInstallations/installations.d/broken.conf
+++ b/tests/content/brokenInstallations/installations.d/broken.conf
@@ -1,0 +1,1 @@
+this is not a valid keyfile at all {{{ .,'?

--- a/tests/content/system/flatpak/app/com.test.InvalidTimestamp/current/active/files/share/metainfo/com.test.InvalidTimestamp.metainfo.xml
+++ b/tests/content/system/flatpak/app/com.test.InvalidTimestamp/current/active/files/share/metainfo/com.test.InvalidTimestamp.metainfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>com.test.InvalidTimestamp</id>
+  <name>Invalid Timestamp</name>
+  <Author>Yooh</Author>
+  <summary>minimal test application</summary>
+  <releases>
+    <release version="0.0.1" timestamp="999999999999999"/>
+  </releases>
+</component>

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -96,6 +96,7 @@ const _usbKey = 'enumerable-devices';
 const _usbHiddenKey = 'hidden-devices';
 
 const _flatpakConfig = GLib.build_filenamev(['..', 'tests', 'content']);
+const _customInstallationConfig = GLib.build_filenamev(['..', 'tests', 'content', 'brokenInstallations']);
 
 
 describe('Model', function() {
@@ -127,6 +128,7 @@ describe('Model', function() {
         GLib.setenv('FLATPAK_SYSTEM_DIR', _system, true);
         GLib.setenv('FLATPAK_USER_DIR', _none, true);
         GLib.setenv('FLATPAK_INFO_PATH', _flatpakInfo, true);
+        GLib.setenv('FLATPAK_CONFIG_DIR', _flatpakConfig, true);
 
         infoDefault.reload();
         portalsDefault.reload();
@@ -766,6 +768,15 @@ describe('Model', function() {
 
         expect(permissionsDefault.shared_network).toBe(false);
         expect(permissionsDefault.shared_ipc).toBe(true);
+    });
+
+    it('does not crash when a custom installation config is malformed', function() {
+        GLib.setenv('FLATPAK_CONFIG_DIR', _customInstallationConfig, true);
+
+        expect(() => applicationsDefault.reload()).not.toThrow();
+
+        const appIds = applicationsDefault.getAll().map(a => a.appId);
+        expect(appIds).toContain(_basicAppId);
     });
 
     it('add new environment variable', function(done) {

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -57,6 +57,7 @@ const _globalRestoredAppId = 'com.test.GlobalRestored';
 const _statusesAppId = 'com.test.Statuses';
 const _malformedAppId = 'com.test.Malformed';
 const _conditionalAppId = 'com.test.Conditional';
+const _invalidTimestampAppId = 'com.test.InvalidTimestamp';
 
 const _flatpakInfo = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info']);
 const _flatpakInfoOld = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info.old']);
@@ -171,6 +172,16 @@ describe('Model', function() {
 
         const appIds = applicationsDefault.getAll().map(a => a.appId);
         expect(appIds).not.toContain(_baseAppId);
+    });
+
+    it('does not crash on an out-of-range release timestamp', function() {
+        expect(() => applicationsDefault.getAppDataForAppId(_invalidTimestampAppId)).not.toThrow();
+
+        const appdata = applicationsDefault.getAppDataForAppId(_invalidTimestampAppId);
+        expect(appdata.date).toEqual(_('Unknown'));
+
+        const appIds = applicationsDefault.getAll().map(a => a.appId);
+        expect(appIds).toContain(_invalidTimestampAppId);
     });
 
     it('loads permissions', function() {


### PR DESCRIPTION
Flatseal reads data from installed applications and custom Flatpak installations. If some of that data is unreadable or malformed, the resulting error can go uncaught and cause Flatseal to fail silently during startup

This fixes the cases found so far and adds regression tests for them.