### PR TITLE
models: Fix crash from malformed app metadata files

### DIFF
--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -250,7 +250,13 @@ var FlatpakApplicationsModel = GObject.registerClass({
             return data;
 
         const keyFile = new GLib.KeyFile();
-        keyFile.load_from_file(path, 0);
+
+        try {
+            keyFile.load_from_file(path, 0);
+        } catch (err) {
+            logError(err, `Could not load metadata ${path}`);
+            return data;
+        }
 
         try {
             data.runtime = keyFile.get_value(group, 'runtime');

--- a/tests/content/system/flatpak/app/com.test.MalformedMetadata/current/active/metadata
+++ b/tests/content/system/flatpak/app/com.test.MalformedMetadata/current/active/metadata
@@ -1,0 +1,1 @@
+this is not a valid keyfile at all {{{

--- a/tests/src/testModels.js
+++ b/tests/src/testModels.js
@@ -58,6 +58,7 @@ const _statusesAppId = 'com.test.Statuses';
 const _malformedAppId = 'com.test.Malformed';
 const _conditionalAppId = 'com.test.Conditional';
 const _invalidTimestampAppId = 'com.test.InvalidTimestamp';
+const _malformedMetadataAppId = 'com.test.MalformedMetadata';
 
 const _flatpakInfo = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info']);
 const _flatpakInfoOld = GLib.build_filenamev(['..', 'tests', 'content', '.flatpak-info.old']);
@@ -184,6 +185,13 @@ describe('Model', function() {
 
         const appIds = applicationsDefault.getAll().map(a => a.appId);
         expect(appIds).toContain(_invalidTimestampAppId);
+    });
+
+    it('does not crash when an app metadata file is malformed', function() {
+        expect(() => applicationsDefault.getMetadataForAppId(_malformedMetadataAppId)).not.toThrow();
+
+        const metadata = applicationsDefault.getMetadataForAppId(_malformedMetadataAppId);
+        expect(metadata.runtime).toEqual(_('Unknown'));
     });
 
     it('loads permissions', function() {


### PR DESCRIPTION
Flatseal reads an app's own metadata file to show its permissions in
the app info viewer. Parsing that file had no error handling, if it
was unreadable or contained invalid syntax, the exception went
uncaught. This is only reachable when opening a specific app's
details, so it would crash Flatseal there rather than at startup.

Includes a regression test using a fixture app with a malformed
metadata file.